### PR TITLE
Fix pickup_start/pickup_end published as tuple instead of string

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ show_error_codes = true
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]
-testpaths = ["tests"]
+testpaths = ["toogoodtogo_ha_mqtt_bridge/tests"]
 
 [tool.ruff]
 target-version = "py39"
@@ -106,7 +106,7 @@ ignore = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/*" = ["S101"]
+"**/tests/*" = ["S101"]
 
 [tool.ruff.format]
 preview = true

--- a/toogoodtogo_ha_mqtt_bridge/main.py
+++ b/toogoodtogo_ha_mqtt_bridge/main.py
@@ -138,8 +138,8 @@ def publish_stores_data(shops: list[Any]) -> bool:
 
         pickup_start_date = None if not stock else arrow.get(shop["pickup_interval"]["start"]).to(tz=settings.timezone)
         pickup_end_date = None if not stock else arrow.get(shop["pickup_interval"]["end"]).to(tz=settings.timezone)
-        pickup_start_str = ("Unknown" if stock == 0 else pickup_start_date.to(tz=settings.timezone).isoformat(),)  # type: ignore[union-attr]
-        pickup_end_str = ("Unknown" if stock == 0 else pickup_end_date.to(tz=settings.timezone).isoformat(),)  # type: ignore[union-attr]
+        pickup_start_str = "Unknown" if stock == 0 else pickup_start_date.to(tz=settings.timezone).isoformat()  # type: ignore[union-attr]
+        pickup_end_str = "Unknown" if stock == 0 else pickup_end_date.to(tz=settings.timezone).isoformat()  # type: ignore[union-attr]
         pickup_start_human = (
             "Unknown" if stock == 0 else pickup_start_date.humanize(only_distance=False, locale=settings.locale)  # type: ignore[union-attr]
         )

--- a/toogoodtogo_ha_mqtt_bridge/tests/test_publish.py
+++ b/toogoodtogo_ha_mqtt_bridge/tests/test_publish.py
@@ -1,0 +1,43 @@
+import json
+from unittest.mock import MagicMock
+
+import paho.mqtt.client as mqtt
+import pytest
+
+from toogoodtogo_ha_mqtt_bridge import main
+from toogoodtogo_ha_mqtt_bridge.config import settings
+
+
+def _fake_shop(stock: int) -> dict:
+    return {
+        "display_name": "Test Store",
+        "items_available": stock,
+        "item": {"item_id": "123", "price": {"minor_units": 499, "decimals": 2}},
+        "pickup_interval": {"start": "2022-01-01T17:00:00Z", "end": "2022-01-01T18:00:00Z"},
+        "store": {"logo_picture": {"current_url": "http://logo"}},
+    }
+
+
+@pytest.mark.parametrize("stock", [3, 0])
+def test_publish_stores_data_attrs(stock: int) -> None:
+    settings["timezone"] = "Europe/Berlin"
+    settings["locale"] = "en_us"
+
+    published: dict[str, str] = {}
+
+    def fake_publish(topic: str, payload: str | None = None) -> MagicMock:
+        published[topic] = payload  # type: ignore[assignment]
+        return MagicMock(rc=mqtt.MQTT_ERR_SUCCESS)
+
+    main.mqtt_client = MagicMock()
+    main.mqtt_client.publish.side_effect = fake_publish
+
+    assert main.publish_stores_data([_fake_shop(stock=stock)]) is True
+
+    attrs = json.loads(published["homeassistant/sensor/toogoodtogo_123/attr"])
+    # Regression for the trailing-comma bug: these must be plain strings,
+    # not 1-tuples serialized as JSON arrays.
+    assert isinstance(attrs["pickup_start"], str)
+    assert isinstance(attrs["pickup_end"], str)
+    assert attrs["price"] == 4.99
+    assert attrs["stock_available"] is (stock > 0)

--- a/toogoodtogo_ha_mqtt_bridge/tests/test_publish.py
+++ b/toogoodtogo_ha_mqtt_bridge/tests/test_publish.py
@@ -1,4 +1,5 @@
 import json
+from collections.abc import Generator
 from unittest.mock import MagicMock
 
 import paho.mqtt.client as mqtt
@@ -18,11 +19,21 @@ def _fake_shop(stock: int) -> dict:
     }
 
 
-@pytest.mark.parametrize("stock", [3, 0])
-def test_publish_stores_data_attrs(stock: int) -> None:
+@pytest.fixture
+def _settings_env() -> Generator[None, None, None]:
+    # dynaconf's settings object has no __delitem__, so snapshot/restore the
+    # keys we touch instead of using monkeypatch.setitem (whose teardown deletes).
+    keys = ("timezone", "locale")
+    original = {key: settings.get(key) for key in keys}
     settings["timezone"] = "Europe/Berlin"
     settings["locale"] = "en_us"
+    yield
+    for key, value in original.items():
+        settings[key] = value
 
+
+@pytest.mark.parametrize("stock", [3, 0])
+def test_publish_stores_data_attrs(stock: int, _settings_env: None) -> None:
     published: dict[str, str] = {}
 
     def fake_publish(topic: str, payload: str | None = None) -> MagicMock:


### PR DESCRIPTION
## The bug
A trailing comma in `publish_stores_data` made `pickup_start_str`/`pickup_end_str` **1-tuples** instead of strings:

```python
pickup_start_str = ("Unknown" if stock == 0 else ....isoformat(),)  # <- trailing comma
```

So the MQTT `pickup_start` / `pickup_end` attributes were serialized as JSON **arrays** (`["2022-..."]`) rather than timestamp strings, breaking HA templates that treat them as timestamps. `pickup_start_human` was unaffected, which is why it went unnoticed.

## Fix
- Drop the trailing comma so both are plain strings.
- Add a regression test for `publish_stores_data` (parametrized over `stock>0` and `stock==0`) asserting the attrs are strings and price parsing works. Verified it fails on the old code and passes on the new.

## Drive-by test-infra fixes (needed for the test to run)
- `pytest` `testpaths` pointed at `./tests`, but tests live under `toogoodtogo_ha_mqtt_bridge/tests/` — pytest printed *"No files were found in testpaths"* and fell back to recursive discovery. Fixed.
- The ruff `per-file-ignores` glob `tests/*` never matched the nested test dir, so `S101` (assert in tests) would have fired. Fixed to `**/tests/*`.

`pytest` (4 passed), `mypy`, and `ruff` all green locally.