### PR TITLE
ci: add non-gating Python compatibility probe (3.12/3.13/3.14)

### DIFF
--- a/.github/workflows/python-compat.yaml
+++ b/.github/workflows/python-compat.yaml
@@ -1,15 +1,22 @@
 name: Python compatibility probe
 
-# Informational, non-gating probe: does the test suite run on newer Python
+# Informational, NON-GATING probe: does the test suite run on newer Python
 # versions? The authoritative test (pinned 3.12 + locked deps) lives in
 # pytest.yaml. This probe keeps requires-python ("==3.12.*") and the lockfile
 # untouched; it installs the project with --ignore-requires-python and lets pip
 # resolve dependencies fresh per version, which mirrors what a real Python bump
 # (e.g. a Renovate "Update Python" PR) actually does.
+#
+# A red result here is INFORMATIONAL ONLY: a dependency that fails to import on
+# a newer interpreter and a genuine test regression both surface as a failure.
+# Do NOT add this workflow to required status checks — it must never block a merge.
 
 on:
-  push:
+  pull_request:
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   compat:
@@ -22,7 +29,7 @@ jobs:
         python-version: ["3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # setuptools_scm needs history/tags to derive the version
 
@@ -36,3 +43,8 @@ jobs:
 
       - name: Run tests
         run: pytest
+
+      - name: Smoke-run the entrypoint
+        # Cheapest "does the app import and start under this interpreter" check;
+        # catches import-time breakage the thin test suite would miss.
+        run: python toogoodtogo_ha_mqtt_bridge/main.py --version

--- a/.github/workflows/python-compat.yaml
+++ b/.github/workflows/python-compat.yaml
@@ -1,0 +1,38 @@
+name: Python compatibility probe
+
+# Informational, non-gating probe: does the test suite run on newer Python
+# versions? The authoritative test (pinned 3.12 + locked deps) lives in
+# pytest.yaml. This probe keeps requires-python ("==3.12.*") and the lockfile
+# untouched; it installs the project with --ignore-requires-python and lets pip
+# resolve dependencies fresh per version, which mirrors what a real Python bump
+# (e.g. a Renovate "Update Python" PR) actually does.
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  compat:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # one version failing should not hide the others
+      matrix:
+        # 3.12 is the current deploy target (control); 3.13 and 3.14 are the
+        # forward-looking probes.
+        python-version: ["3.12", "3.13", "3.14"]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # setuptools_scm needs history/tags to derive the version
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install project (bypassing the requires-python pin) and pytest
+        run: pip install --ignore-requires-python -e . pytest
+
+      - name: Run tests
+        run: pytest


### PR DESCRIPTION
Adds an informational CI matrix that runs the test suite on newer Python versions, so future Python bumps (e.g. #263, the 3.12→3.14 PR) are evidence-based instead of guesswork.

## How it works
- New workflow `.github/workflows/python-compat.yaml`, matrix over **3.12 (control) / 3.13 / 3.14**, `fail-fast: false`.
- Installs with `pip install --ignore-requires-python -e . pytest` and lets pip resolve deps **fresh per version** — which mirrors what a real Python bump does (Renovate re-locks).
- **Leaves `requires-python` (`==3.12.*`) and `uv.lock` untouched.** `pytest.yaml` stays the authoritative pinned-3.12 + locked-deps gate; this probe is purely informational.

## First run
All three versions pass ✅ — including 3.14, which is the key signal for #263: the dependency set (tgtg, paho-mqtt, google-play-scraper, …) installs and imports on 3.14.

_Caveat: the probe is only as strong as the suite. `main` currently has just the cron tests; merging #280 (which adds publish tests) would strengthen this probe automatically._