### PR TITLE
ci: set persist-credentials: false on all checkout steps

### DIFF
--- a/.github/workflows/docker-build-and-push-as-rel.yaml
+++ b/.github/workflows/docker-build-and-push-as-rel.yaml
@@ -13,6 +13,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Fetch the entire history to include the .git directory
+          persist-credentials: false
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -14,6 +14,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Fetch the entire history to include the .git directory
+          persist-credentials: false
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx

--- a/.github/workflows/docker-buld-push-as-testing.yaml
+++ b/.github/workflows/docker-buld-push-as-testing.yaml
@@ -13,6 +13,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Fetch the entire history to include the .git directory
+          persist-credentials: false
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,6 +8,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: pkgxdev/setup@v4
         with:
           +: task

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -8,6 +8,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0

--- a/.github/workflows/python-compat.yaml
+++ b/.github/workflows/python-compat.yaml
@@ -32,6 +32,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # setuptools_scm needs history/tags to derive the version
+          persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6


### PR DESCRIPTION
Follow-up to the CodeRabbit review on #282.

CodeRabbit/`zizmor` flagged (`artipacked`) that `actions/checkout` persists a writable `GITHUB_TOKEN` in `.git/config` by default, leaving it readable by later steps. None of these workflows push back to git (the docker workflows authenticate to DockerHub via `docker/login-action`, not the git token), so none need the persisted credential.

Applied repo-wide (all 7 workflows) rather than just the new `python-compat.yaml`, so the posture is consistent instead of one-file-hardened.

_Note: the other zizmor finding (pin actions to commit SHAs) is intentionally **not** included — that is a repo-wide policy decision best paired with Renovate digest-pinning, deferred for now._