### PR TITLE
renovate: enable monthly lockFileMaintenance

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", "schedule:monthly"],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 4am on the first day of the month"]
+  },
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
Restores the transitive/lockfile dependency coverage that was lost when Dependabot was removed (commit `71dd771`).

### Why
`config:recommended` only raises PRs for **declared** dependencies. Transitive deps that live only in `uv.lock` (e.g. `virtualenv`, pulled in by `pre-commit`) had no bot watching them once Dependabot — which *did* update lockfile transitives via its uv support — was removed. The orphaned Dependabot virtualenv PR (#276) was a symptom of that gap.

### What
Enables `lockFileMaintenance`, which opens a single periodic *refresh-the-whole-lockfile* PR (cleaner than per-package transitive PRs). Scheduled **monthly** to match the existing `schedule:monthly` cadence and keep noise low.

Validated with `renovate-config-validator` ("Config validated successfully").