### PR TITLE
feat: stable entity IDs via default_entity_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,10 +136,18 @@ sensor:
         unit_of_measurement: "€"
         icon_template: mdi:currency-eur
         friendly_name: "Eilles Frankfurt Price"
-        value_template: "{{ state_attr('sensor.toogoodtogo_eilles_frankfurt', 'price') }}"
+        value_template: "{{ state_attr('sensor.toogoodtogo_123456', 'price') }}"
 ```
 
 ## Get a list of all toogoodtogo sensors:
+
+> [!NOTE]
+> **Entity IDs changed.** Newly discovered sensors now get a short, stable ID based on the
+> store's immutable TooGoodToGo item ID — e.g. `sensor.toogoodtogo_123456` — instead of one
+> derived from the (changeable) store name. Existing sensors keep their current IDs: Home
+> Assistant never renames an entity once created, so only stores favourited after updating use
+> the new scheme. Older installs may therefore show a mix of `sensor.toogoodtogo_…` and the
+> legacy `sensor.too_good_to_go_toogoodtogo_…` forms.
 
 Add the following piece of code into /developer-tools/template in HomeAssistant. (Remove the last comma)
 
@@ -235,12 +243,12 @@ description: ""
 triggers:
   - trigger: time
     at:
-      entity_id: sensor.too_good_to_go_toogoodtogo_next_collection
+      entity_id: sensor.toogoodtogo_next_collection
       offset: "-00:30:00"
 
 actions:
   - variables:
-      next_collection_entity: sensor.too_good_to_go_toogoodtogo_next_collection
+      next_collection_entity: sensor.toogoodtogo_next_collection
       notification_message: |-
         🛍️ <b>Too Good To Go Pickup Reminder</b>
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,12 @@ sensor:
 > Assistant never renames an entity once created, so only stores favourited after updating use
 > the new scheme. Older installs may therefore show a mix of `sensor.toogoodtogo_…` and the
 > legacy `sensor.too_good_to_go_toogoodtogo_…` forms.
+>
+> To migrate existing sensors to the new IDs, open the **Too Good To Go** device in Home
+> Assistant, select the three-dots menu and choose **Recreate entity IDs** (see the
+> [Home Assistant docs](https://www.home-assistant.io/docs/configuration/customizing-devices/)).
+> Heads-up: this does **not** update references in your automations, scripts or dashboards — you
+> have to fix those manually.
 
 Add the following piece of code into /developer-tools/template in HomeAssistant. (Remove the last comma)
 

--- a/toogoodtogo_ha_mqtt_bridge/main.py
+++ b/toogoodtogo_ha_mqtt_bridge/main.py
@@ -116,19 +116,19 @@ def publish_stores_data(shops: list[Any]) -> bool:
         logger.debug(f"Pushing message for {shop['display_name']} // {item_id}")
 
         # Autodiscover
-        result_ad = mqtt_client.publish(
-            f"homeassistant/sensor/toogoodtogo_bridge/{item_id}/config",
-            json.dumps({
-                **entity_naming(f"toogoodtogo_{item_id}", f"TooGoodToGo - {shop['display_name']}"),
-                "icon": "mdi:food" if stock > 0 else "mdi:food-off",
-                "state_topic": f"homeassistant/sensor/toogoodtogo_{item_id}/state",
-                "json_attributes_topic": f"homeassistant/sensor/toogoodtogo_{item_id}/attr",
-                "unit_of_measurement": "portions",
-                "value_template": "{{ value_json.stock }}",
-                "device": DEVICE_INFO,
-                "unique_id": f"toogoodtogo_{item_id}",
-            }),
-        )
+        config_topic = f"homeassistant/sensor/toogoodtogo_bridge/{item_id}/config"
+        config_payload = {
+            **entity_naming(f"toogoodtogo_{item_id}", f"TooGoodToGo - {shop['display_name']}"),
+            "icon": "mdi:food" if stock > 0 else "mdi:food-off",
+            "state_topic": f"homeassistant/sensor/toogoodtogo_{item_id}/state",
+            "json_attributes_topic": f"homeassistant/sensor/toogoodtogo_{item_id}/attr",
+            "unit_of_measurement": "portions",
+            "value_template": "{{ value_json.stock }}",
+            "device": DEVICE_INFO,
+            "unique_id": f"toogoodtogo_{item_id}",
+        }
+        logger.debug(f"Publishing discovery config to {config_topic}: {json.dumps(config_payload)}")
+        result_ad = mqtt_client.publish(config_topic, json.dumps(config_payload))
 
         result_state = mqtt_client.publish(
             f"homeassistant/sensor/toogoodtogo_{item_id}/state",

--- a/toogoodtogo_ha_mqtt_bridge/main.py
+++ b/toogoodtogo_ha_mqtt_bridge/main.py
@@ -51,18 +51,22 @@ DEVICE_INFO = {
 }
 
 
-def entity_naming(object_id: str, name: str) -> dict[str, Any]:
+def entity_naming(default_entity_id: str, name: str) -> dict[str, Any]:
     """Naming keys for an MQTT discovery payload.
 
-    Pins ``object_id`` to the stable unique id so Home Assistant derives the ``entity_id``
-    from it (e.g. ``sensor.toogoodtogo_123456``) instead of from the volatile store display
-    name. ``has_entity_name`` is deliberately NOT set: with it, Home Assistant builds the
-    entity_id from the device + entity name and ignores ``object_id`` entirely.
+    Sets ``default_entity_id`` so Home Assistant derives the entity_id from the stable unique
+    id (e.g. ``sensor.toogoodtogo_123456``) instead of from the volatile store display name.
+    This is the modern replacement for the payload ``object_id`` field, which HA deprecated in
+    Core 2025.10 and removed in Core 2026.4; ``default_entity_id`` MUST include the domain
+    prefix (``sensor.`` / ``switch.``).
 
-    Note: this only affects newly discovered entities. Home Assistant freezes an existing
-    entity's ``entity_id`` at registration, so already-known sensors keep their current id.
+    Only affects newly discovered entities: with a ``unique_id`` set, HA applies
+    ``default_entity_id`` on first registration only, so existing entities keep their id.
+    HA forces ``has_entity_name=True`` on every MQTT entity, so the friendly name is always
+    prefixed with the device name ("Too Good To Go"); ``name`` is therefore the brand-free
+    sub-name (e.g. the store) to avoid duplicating the brand.
     """
-    return {"name": name, "object_id": object_id}
+    return {"name": name, "default_entity_id": default_entity_id}
 
 
 def check() -> bool:
@@ -118,7 +122,7 @@ def publish_stores_data(shops: list[Any]) -> bool:
         # Autodiscover
         config_topic = f"homeassistant/sensor/toogoodtogo_bridge/{item_id}/config"
         config_payload = {
-            **entity_naming(f"toogoodtogo_{item_id}", f"TooGoodToGo - {shop['display_name']}"),
+            **entity_naming(f"sensor.toogoodtogo_{item_id}", shop["display_name"]),
             "icon": "mdi:food" if stock > 0 else "mdi:food-off",
             "state_topic": f"homeassistant/sensor/toogoodtogo_{item_id}/state",
             "json_attributes_topic": f"homeassistant/sensor/toogoodtogo_{item_id}/attr",
@@ -203,7 +207,7 @@ def publish_orders_data(active_orders: dict) -> bool:
     result_ad = mqtt_client.publish(
         "homeassistant/sensor/toogoodtogo_next_collection/config",
         json.dumps({
-            **entity_naming("toogoodtogo_next_collection", "TooGoodToGo - Next Collection"),
+            **entity_naming("sensor.toogoodtogo_next_collection", "Next Collection"),
             "icon": "mdi:calendar-clock" if has_orders else "mdi:calendar-remove",
             "device_class": "timestamp",
             "entity_category": "diagnostic",
@@ -217,7 +221,7 @@ def publish_orders_data(active_orders: dict) -> bool:
     result_ad_count = mqtt_client.publish(
         "homeassistant/sensor/toogoodtogo_upcoming_orders/config",
         json.dumps({
-            **entity_naming("toogoodtogo_upcoming_orders", "TooGoodToGo - Upcoming Orders"),
+            **entity_naming("sensor.toogoodtogo_upcoming_orders", "Upcoming Orders"),
             "icon": "mdi:cart" if has_orders else "mdi:cart-off",
             "entity_category": "diagnostic",
             "state_topic": "homeassistant/sensor/toogoodtogo_upcoming_orders/state",
@@ -354,7 +358,7 @@ def publish_last_updated() -> bool:
     result_ad = mqtt_client.publish(
         "homeassistant/sensor/toogoodtogo_last_updated/config",
         json.dumps({
-            **entity_naming("toogoodtogo_last_updated", "TooGoodToGo - Last Updated"),
+            **entity_naming("sensor.toogoodtogo_last_updated", "Last Updated"),
             "icon": "mdi:clock-outline",
             "device_class": "timestamp",
             "entity_category": "diagnostic",
@@ -775,7 +779,7 @@ def register_fetch_sensor() -> None:
     mqtt_client.publish(
         "homeassistant/switch/toogoodtogo_bridge/intense_fetch/config",
         json.dumps({
-            **entity_naming("toogoodtogo_intense_fetch_switch", "Intense fetch"),
+            **entity_naming("switch.toogoodtogo_intense_fetch_switch", "Intense fetch"),
             "icon": "mdi:fast-forward",
             "state_topic": "homeassistant/switch/toogoodtogo_intense_fetch/state",
             "command_topic": "homeassistant/switch/toogoodtogo_intense_fetch/set",

--- a/toogoodtogo_ha_mqtt_bridge/main.py
+++ b/toogoodtogo_ha_mqtt_bridge/main.py
@@ -120,19 +120,19 @@ def publish_stores_data(shops: list[Any]) -> bool:
         logger.debug(f"Pushing message for {shop['display_name']} // {item_id}")
 
         # Autodiscover
-        config_topic = f"homeassistant/sensor/toogoodtogo_bridge/{item_id}/config"
-        config_payload = {
-            **entity_naming(f"sensor.toogoodtogo_{item_id}", shop["display_name"]),
-            "icon": "mdi:food" if stock > 0 else "mdi:food-off",
-            "state_topic": f"homeassistant/sensor/toogoodtogo_{item_id}/state",
-            "json_attributes_topic": f"homeassistant/sensor/toogoodtogo_{item_id}/attr",
-            "unit_of_measurement": "portions",
-            "value_template": "{{ value_json.stock }}",
-            "device": DEVICE_INFO,
-            "unique_id": f"toogoodtogo_{item_id}",
-        }
-        logger.debug(f"Publishing discovery config to {config_topic}: {json.dumps(config_payload)}")
-        result_ad = mqtt_client.publish(config_topic, json.dumps(config_payload))
+        result_ad = mqtt_client.publish(
+            f"homeassistant/sensor/toogoodtogo_bridge/{item_id}/config",
+            json.dumps({
+                **entity_naming(f"sensor.toogoodtogo_{item_id}", shop["display_name"]),
+                "icon": "mdi:food" if stock > 0 else "mdi:food-off",
+                "state_topic": f"homeassistant/sensor/toogoodtogo_{item_id}/state",
+                "json_attributes_topic": f"homeassistant/sensor/toogoodtogo_{item_id}/attr",
+                "unit_of_measurement": "portions",
+                "value_template": "{{ value_json.stock }}",
+                "device": DEVICE_INFO,
+                "unique_id": f"toogoodtogo_{item_id}",
+            }),
+        )
 
         result_state = mqtt_client.publish(
             f"homeassistant/sensor/toogoodtogo_{item_id}/state",

--- a/toogoodtogo_ha_mqtt_bridge/main.py
+++ b/toogoodtogo_ha_mqtt_bridge/main.py
@@ -51,6 +51,20 @@ DEVICE_INFO = {
 }
 
 
+def entity_naming(object_id: str, name: str) -> dict[str, Any]:
+    """Naming keys for an MQTT discovery payload.
+
+    Pins ``object_id`` to the stable unique id so Home Assistant derives the ``entity_id``
+    from it (e.g. ``sensor.toogoodtogo_123456``) instead of from the volatile store display
+    name, and sets ``has_entity_name`` so the device brand ("Too Good To Go") is not
+    duplicated in the friendly name.
+
+    Note: this only affects newly discovered entities. Home Assistant freezes an existing
+    entity's ``entity_id`` at registration, so already-known sensors keep their current id.
+    """
+    return {"name": name, "object_id": object_id, "has_entity_name": True}
+
+
 def check() -> bool:
     global first_run
 
@@ -105,7 +119,7 @@ def publish_stores_data(shops: list[Any]) -> bool:
         result_ad = mqtt_client.publish(
             f"homeassistant/sensor/toogoodtogo_bridge/{item_id}/config",
             json.dumps({
-                "name": f"TooGoodToGo - {shop['display_name']}",
+                **entity_naming(f"toogoodtogo_{item_id}", shop["display_name"]),
                 "icon": "mdi:food" if stock > 0 else "mdi:food-off",
                 "state_topic": f"homeassistant/sensor/toogoodtogo_{item_id}/state",
                 "json_attributes_topic": f"homeassistant/sensor/toogoodtogo_{item_id}/attr",
@@ -189,7 +203,7 @@ def publish_orders_data(active_orders: dict) -> bool:
     result_ad = mqtt_client.publish(
         "homeassistant/sensor/toogoodtogo_next_collection/config",
         json.dumps({
-            "name": "TooGoodToGo - Next Collection",
+            **entity_naming("toogoodtogo_next_collection", "Next Collection"),
             "icon": "mdi:calendar-clock" if has_orders else "mdi:calendar-remove",
             "device_class": "timestamp",
             "entity_category": "diagnostic",
@@ -203,7 +217,7 @@ def publish_orders_data(active_orders: dict) -> bool:
     result_ad_count = mqtt_client.publish(
         "homeassistant/sensor/toogoodtogo_upcoming_orders/config",
         json.dumps({
-            "name": "TooGoodToGo - Upcoming Orders",
+            **entity_naming("toogoodtogo_upcoming_orders", "Upcoming Orders"),
             "icon": "mdi:cart" if has_orders else "mdi:cart-off",
             "entity_category": "diagnostic",
             "state_topic": "homeassistant/sensor/toogoodtogo_upcoming_orders/state",
@@ -340,7 +354,7 @@ def publish_last_updated() -> bool:
     result_ad = mqtt_client.publish(
         "homeassistant/sensor/toogoodtogo_last_updated/config",
         json.dumps({
-            "name": "TooGoodToGo - Last Updated",
+            **entity_naming("toogoodtogo_last_updated", "Last Updated"),
             "icon": "mdi:clock-outline",
             "device_class": "timestamp",
             "entity_category": "diagnostic",
@@ -761,7 +775,7 @@ def register_fetch_sensor() -> None:
     mqtt_client.publish(
         "homeassistant/switch/toogoodtogo_bridge/intense_fetch/config",
         json.dumps({
-            "name": "Intense fetch",
+            **entity_naming("toogoodtogo_intense_fetch_switch", "Intense fetch"),
             "icon": "mdi:fast-forward",
             "state_topic": "homeassistant/switch/toogoodtogo_intense_fetch/state",
             "command_topic": "homeassistant/switch/toogoodtogo_intense_fetch/set",

--- a/toogoodtogo_ha_mqtt_bridge/main.py
+++ b/toogoodtogo_ha_mqtt_bridge/main.py
@@ -56,13 +56,13 @@ def entity_naming(object_id: str, name: str) -> dict[str, Any]:
 
     Pins ``object_id`` to the stable unique id so Home Assistant derives the ``entity_id``
     from it (e.g. ``sensor.toogoodtogo_123456``) instead of from the volatile store display
-    name, and sets ``has_entity_name`` so the device brand ("Too Good To Go") is not
-    duplicated in the friendly name.
+    name. ``has_entity_name`` is deliberately NOT set: with it, Home Assistant builds the
+    entity_id from the device + entity name and ignores ``object_id`` entirely.
 
     Note: this only affects newly discovered entities. Home Assistant freezes an existing
     entity's ``entity_id`` at registration, so already-known sensors keep their current id.
     """
-    return {"name": name, "object_id": object_id, "has_entity_name": True}
+    return {"name": name, "object_id": object_id}
 
 
 def check() -> bool:
@@ -119,7 +119,7 @@ def publish_stores_data(shops: list[Any]) -> bool:
         result_ad = mqtt_client.publish(
             f"homeassistant/sensor/toogoodtogo_bridge/{item_id}/config",
             json.dumps({
-                **entity_naming(f"toogoodtogo_{item_id}", shop["display_name"]),
+                **entity_naming(f"toogoodtogo_{item_id}", f"TooGoodToGo - {shop['display_name']}"),
                 "icon": "mdi:food" if stock > 0 else "mdi:food-off",
                 "state_topic": f"homeassistant/sensor/toogoodtogo_{item_id}/state",
                 "json_attributes_topic": f"homeassistant/sensor/toogoodtogo_{item_id}/attr",
@@ -203,7 +203,7 @@ def publish_orders_data(active_orders: dict) -> bool:
     result_ad = mqtt_client.publish(
         "homeassistant/sensor/toogoodtogo_next_collection/config",
         json.dumps({
-            **entity_naming("toogoodtogo_next_collection", "Next Collection"),
+            **entity_naming("toogoodtogo_next_collection", "TooGoodToGo - Next Collection"),
             "icon": "mdi:calendar-clock" if has_orders else "mdi:calendar-remove",
             "device_class": "timestamp",
             "entity_category": "diagnostic",
@@ -217,7 +217,7 @@ def publish_orders_data(active_orders: dict) -> bool:
     result_ad_count = mqtt_client.publish(
         "homeassistant/sensor/toogoodtogo_upcoming_orders/config",
         json.dumps({
-            **entity_naming("toogoodtogo_upcoming_orders", "Upcoming Orders"),
+            **entity_naming("toogoodtogo_upcoming_orders", "TooGoodToGo - Upcoming Orders"),
             "icon": "mdi:cart" if has_orders else "mdi:cart-off",
             "entity_category": "diagnostic",
             "state_topic": "homeassistant/sensor/toogoodtogo_upcoming_orders/state",
@@ -354,7 +354,7 @@ def publish_last_updated() -> bool:
     result_ad = mqtt_client.publish(
         "homeassistant/sensor/toogoodtogo_last_updated/config",
         json.dumps({
-            **entity_naming("toogoodtogo_last_updated", "Last Updated"),
+            **entity_naming("toogoodtogo_last_updated", "TooGoodToGo - Last Updated"),
             "icon": "mdi:clock-outline",
             "device_class": "timestamp",
             "entity_category": "diagnostic",

--- a/toogoodtogo_ha_mqtt_bridge/tests/test_publish.py
+++ b/toogoodtogo_ha_mqtt_bridge/tests/test_publish.py
@@ -59,3 +59,22 @@ def test_publish_stores_data_attrs(stock: int, _settings_env: None) -> None:
     config = json.loads(published["homeassistant/sensor/toogoodtogo_bridge/123/config"])
     assert config["default_entity_id"] == "sensor.toogoodtogo_123"
     assert config["name"] == "Test Store"
+
+
+def test_register_fetch_sensor_naming() -> None:
+    # The switch is the only non-sensor entity, so its default_entity_id must carry the
+    # switch. domain (not sensor.). Covers the distinct domain path of entity_naming.
+    published: dict[str, str] = {}
+
+    def fake_publish(topic: str, payload: str | None = None) -> MagicMock:
+        published[topic] = payload  # type: ignore[assignment]
+        return MagicMock(rc=mqtt.MQTT_ERR_SUCCESS)
+
+    main.mqtt_client = MagicMock()
+    main.mqtt_client.publish.side_effect = fake_publish
+
+    main.register_fetch_sensor()
+
+    config = json.loads(published["homeassistant/switch/toogoodtogo_bridge/intense_fetch/config"])
+    assert config["default_entity_id"] == "switch.toogoodtogo_intense_fetch_switch"
+    assert config["name"] == "Intense fetch"

--- a/toogoodtogo_ha_mqtt_bridge/tests/test_publish.py
+++ b/toogoodtogo_ha_mqtt_bridge/tests/test_publish.py
@@ -53,10 +53,10 @@ def test_publish_stores_data_attrs(stock: int, _settings_env: None) -> None:
     assert attrs["price"] == 4.99
     assert attrs["stock_available"] is (stock > 0)
 
-    # Stable entity-id naming: config pins object_id to the immutable item id and uses
-    # has_entity_name, so the entity_id is sensor.toogoodtogo_<id> and the brand isn't
-    # duplicated in the name (no "TooGoodToGo - " prefix).
+    # Stable entity-id naming: config pins object_id to the immutable item id so the
+    # entity_id derives from it (sensor.toogoodtogo_<id>) rather than the store name.
+    # has_entity_name is intentionally absent (it makes HA ignore object_id).
     config = json.loads(published["homeassistant/sensor/toogoodtogo_bridge/123/config"])
     assert config["object_id"] == "toogoodtogo_123"
-    assert config["has_entity_name"] is True
-    assert config["name"] == "Test Store"
+    assert "has_entity_name" not in config
+    assert config["name"] == "TooGoodToGo - Test Store"

--- a/toogoodtogo_ha_mqtt_bridge/tests/test_publish.py
+++ b/toogoodtogo_ha_mqtt_bridge/tests/test_publish.py
@@ -53,10 +53,9 @@ def test_publish_stores_data_attrs(stock: int, _settings_env: None) -> None:
     assert attrs["price"] == 4.99
     assert attrs["stock_available"] is (stock > 0)
 
-    # Stable entity-id naming: config pins object_id to the immutable item id so the
-    # entity_id derives from it (sensor.toogoodtogo_<id>) rather than the store name.
-    # has_entity_name is intentionally absent (it makes HA ignore object_id).
+    # Stable entity-id naming: default_entity_id (domain-prefixed) pins the entity_id to the
+    # immutable item id (sensor.toogoodtogo_<id>) instead of the volatile store name. name is
+    # the brand-free sub-name (HA forces has_entity_name=True, prefixing the device brand).
     config = json.loads(published["homeassistant/sensor/toogoodtogo_bridge/123/config"])
-    assert config["object_id"] == "toogoodtogo_123"
-    assert "has_entity_name" not in config
-    assert config["name"] == "TooGoodToGo - Test Store"
+    assert config["default_entity_id"] == "sensor.toogoodtogo_123"
+    assert config["name"] == "Test Store"

--- a/toogoodtogo_ha_mqtt_bridge/tests/test_publish.py
+++ b/toogoodtogo_ha_mqtt_bridge/tests/test_publish.py
@@ -52,3 +52,11 @@ def test_publish_stores_data_attrs(stock: int, _settings_env: None) -> None:
     assert isinstance(attrs["pickup_end"], str)
     assert attrs["price"] == 4.99
     assert attrs["stock_available"] is (stock > 0)
+
+    # Stable entity-id naming: config pins object_id to the immutable item id and uses
+    # has_entity_name, so the entity_id is sensor.toogoodtogo_<id> and the brand isn't
+    # duplicated in the name (no "TooGoodToGo - " prefix).
+    config = json.loads(published["homeassistant/sensor/toogoodtogo_bridge/123/config"])
+    assert config["object_id"] == "toogoodtogo_123"
+    assert config["has_entity_name"] is True
+    assert config["name"] == "Test Store"


### PR DESCRIPTION
Makes entity_ids short and stable (`sensor.toogoodtogo_<item_id>`) instead of derived from each store's long, mutable TGTG display name.

### How HA actually generates the entity_id (researched)
- The discovery topic's `object_id`/`node_id` segments **do not** influence the entity_id.
- HA forces `has_entity_name=True` on **every** MQTT entity, so the friendly name is always prefixed with the device name and the entity_id is device-name-derived **unless overridden**.
- The override field is **`default_entity_id`** (must include the domain, e.g. `sensor.xxx`). The old payload **`object_id` field was deprecated in HA Core 2025.10 and removed in 2026.4** — which is why earlier attempts using `object_id` were silently ignored.
- With a `unique_id` set, `default_entity_id` is applied **on first registration only** — existing entities keep their current id.

### Change
All discovery payloads now set `default_entity_id` (domain-prefixed) to the stable unique id, and use **brand-free names** (`name` = the store / sub-name, not `TooGoodToGo - …`) since HA prepends the device brand itself.

Result for newly discovered entities:
- `sensor.toogoodtogo_123456` (short, stable, survives store renames)
- friendly name `Too Good To Go <store>` (brand once, not doubled)

### Migration
- **Existing entity_ids are unchanged** (first-registration-only). Only newly favourited stores get the new id. Friendly names of existing entities tidy up (cosmetic).
- Changelog should note the new scheme.

### Status
- `pytest` / `mypy` / `ruff` green; test asserts `default_entity_id` is the domain-prefixed stable id and the name is brand-free.
- ⚠️ Pending one real-HA confirmation: delete an entity (or favourite a new store) and verify it comes back as `sensor.toogoodtogo_<item_id>`.

Sources: HA MQTT docs (entity_id / default_entity_id / has_entity_name), HA 2025.10 deprecation + 2026.4 removal of payload `object_id`.