### PR TITLE
fix: retain state/attribute messages so fresh entities aren't "unknown"

### DIFF
--- a/toogoodtogo_ha_mqtt_bridge/main.py
+++ b/toogoodtogo_ha_mqtt_bridge/main.py
@@ -530,6 +530,10 @@ def check_for_removed_stores(shops: list[Any]) -> None:
         for deprecated_item in deprecated_items:
             logger.info(f"Shop {deprecated_item} was not checked, will send remove message")
             result = mqtt_client.publish(f"homeassistant/sensor/toogoodtogo_{deprecated_item}/config")
+            # Clear the now-retained state/attribute topics too, so a removed store leaves no
+            # orphan retained message on the broker (an empty retained payload deletes it).
+            publish_state(f"homeassistant/sensor/toogoodtogo_{deprecated_item}/state")
+            publish_state(f"homeassistant/sensor/toogoodtogo_{deprecated_item}/attr")
             logger.debug(f"Message published: Removal: {bool(result.rc == mqtt.MQTT_ERR_SUCCESS)}")
 
     with open(path, "w") as f:

--- a/toogoodtogo_ha_mqtt_bridge/main.py
+++ b/toogoodtogo_ha_mqtt_bridge/main.py
@@ -69,6 +69,17 @@ def entity_naming(default_entity_id: str, name: str) -> dict[str, Any]:
     return {"name": name, "default_entity_id": default_entity_id}
 
 
+def publish_state(topic: str, payload: str | None = None) -> Any:
+    """Publish a retained state/attribute message.
+
+    State and attribute messages are retained so Home Assistant receives the current value
+    the instant it subscribes. Without retain a freshly discovered entity shows ``unknown``
+    until the next poll, because the value is published before HA has created the entity and
+    subscribed to its topic (issue #85).
+    """
+    return mqtt_client.publish(topic, payload, retain=True)
+
+
 def check() -> bool:
     global first_run
 
@@ -134,7 +145,7 @@ def publish_stores_data(shops: list[Any]) -> bool:
             }),
         )
 
-        result_state = mqtt_client.publish(
+        result_state = publish_state(
             f"homeassistant/sensor/toogoodtogo_{item_id}/state",
             json.dumps({"stock": stock}),
         )
@@ -175,7 +186,7 @@ def publish_stores_data(shops: list[Any]) -> bool:
                 # okay, i give up. Take TGTG brand logo.
                 picture = "https://toogoodtogo.com/images/logo/econ-textless.svg"
 
-        result_attrs = mqtt_client.publish(
+        result_attrs = publish_state(
             f"homeassistant/sensor/toogoodtogo_{item_id}/attr",
             json.dumps({
                 "price": price,
@@ -239,12 +250,12 @@ def publish_orders_data(active_orders: dict) -> bool:
         pickup_date = next_order["pickup_interval"]["start"]
         pickup_date_arrow = arrow.get(pickup_date).to(tz=settings.timezone)
 
-        result_state = mqtt_client.publish(
+        result_state = publish_state(
             "homeassistant/sensor/toogoodtogo_next_collection/state",
             pickup_date_arrow.isoformat(),
         )
 
-        result_attrs = mqtt_client.publish(
+        result_attrs = publish_state(
             "homeassistant/sensor/toogoodtogo_next_collection/attr",
             json.dumps({
                 "order_id": next_order["order_id"],
@@ -263,7 +274,7 @@ def publish_orders_data(active_orders: dict) -> bool:
             }),
         )
 
-        result_state_count = mqtt_client.publish(
+        result_state_count = publish_state(
             "homeassistant/sensor/toogoodtogo_upcoming_orders/state",
             str(len(orders)),
         )
@@ -280,7 +291,7 @@ def publish_orders_data(active_orders: dict) -> bool:
             for order in orders
         ]
 
-        result_attrs_count = mqtt_client.publish(
+        result_attrs_count = publish_state(
             "homeassistant/sensor/toogoodtogo_upcoming_orders/attr",
             json.dumps({"orders": orders_summary}),
         )
@@ -309,19 +320,19 @@ def publish_orders_data(active_orders: dict) -> bool:
             return False
 
     else:
-        result_state = mqtt_client.publish(
+        result_state = publish_state(
             "homeassistant/sensor/toogoodtogo_next_collection/state",
             "null",
         )
-        result_attrs = mqtt_client.publish(
+        result_attrs = publish_state(
             "homeassistant/sensor/toogoodtogo_next_collection/attr",
             json.dumps({}),
         )
-        result_state_count = mqtt_client.publish(
+        result_state_count = publish_state(
             "homeassistant/sensor/toogoodtogo_upcoming_orders/state",
             "0",
         )
-        result_attrs_count = mqtt_client.publish(
+        result_attrs_count = publish_state(
             "homeassistant/sensor/toogoodtogo_upcoming_orders/attr",
             json.dumps({"orders": []}),
         )
@@ -368,7 +379,7 @@ def publish_last_updated() -> bool:
         }),
     )
 
-    result_state = mqtt_client.publish(
+    result_state = publish_state(
         "homeassistant/sensor/toogoodtogo_last_updated/state",
         current_time.isoformat(),
     )

--- a/toogoodtogo_ha_mqtt_bridge/tests/test_publish.py
+++ b/toogoodtogo_ha_mqtt_bridge/tests/test_publish.py
@@ -35,9 +35,11 @@ def _settings_env() -> Generator[None, None, None]:
 @pytest.mark.parametrize("stock", [3, 0])
 def test_publish_stores_data_attrs(stock: int, _settings_env: None) -> None:
     published: dict[str, str] = {}
+    retained: dict[str, bool] = {}
 
-    def fake_publish(topic: str, payload: str | None = None) -> MagicMock:
+    def fake_publish(topic: str, payload: str | None = None, retain: bool = False) -> MagicMock:
         published[topic] = payload  # type: ignore[assignment]
+        retained[topic] = retain
         return MagicMock(rc=mqtt.MQTT_ERR_SUCCESS)
 
     main.mqtt_client = MagicMock()
@@ -52,6 +54,11 @@ def test_publish_stores_data_attrs(stock: int, _settings_env: None) -> None:
     assert isinstance(attrs["pickup_end"], str)
     assert attrs["price"] == 4.99
     assert attrs["stock_available"] is (stock > 0)
+
+    # State/attribute messages must be retained so a freshly discovered entity shows its
+    # value immediately on subscribe instead of 'unknown' until the next poll (issue #85).
+    assert retained["homeassistant/sensor/toogoodtogo_123/state"] is True
+    assert retained["homeassistant/sensor/toogoodtogo_123/attr"] is True
 
     # Stable entity-id naming: default_entity_id (domain-prefixed) pins the entity_id to the
     # immutable item id (sensor.toogoodtogo_<id>) instead of the volatile store name. name is

--- a/toogoodtogo_ha_mqtt_bridge/tests/test_publish.py
+++ b/toogoodtogo_ha_mqtt_bridge/tests/test_publish.py
@@ -1,5 +1,6 @@
 import json
 from collections.abc import Generator
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import paho.mqtt.client as mqtt
@@ -66,6 +67,8 @@ def test_publish_stores_data_attrs(stock: int, _settings_env: None) -> None:
     config = json.loads(published["homeassistant/sensor/toogoodtogo_bridge/123/config"])
     assert config["default_entity_id"] == "sensor.toogoodtogo_123"
     assert config["name"] == "Test Store"
+    # Discovery config is intentionally NOT retained (only state/attrs are).
+    assert retained["homeassistant/sensor/toogoodtogo_bridge/123/config"] is False
 
 
 def test_register_fetch_sensor_naming() -> None:
@@ -85,3 +88,30 @@ def test_register_fetch_sensor_naming() -> None:
     config = json.loads(published["homeassistant/switch/toogoodtogo_bridge/intense_fetch/config"])
     assert config["default_entity_id"] == "switch.toogoodtogo_intense_fetch_switch"
     assert config["name"] == "Intense fetch"
+
+
+def test_check_for_removed_stores_clears_retained(tmp_path: Path) -> None:
+    # A removed store must clear its retained state/attr topics (empty retained payload),
+    # otherwise the retained messages orphan on the broker forever.
+    original_data_dir = settings.get("data_dir")
+    settings["data_dir"] = str(tmp_path)
+    (tmp_path / "known_shops.json").write_text(json.dumps(["999"]))
+    try:
+        published: dict[str, str | None] = {}
+        retained: dict[str, bool] = {}
+
+        def fake_publish(topic: str, payload: str | None = None, retain: bool = False) -> MagicMock:
+            published[topic] = payload
+            retained[topic] = retain
+            return MagicMock(rc=mqtt.MQTT_ERR_SUCCESS)
+
+        main.mqtt_client = MagicMock()
+        main.mqtt_client.publish.side_effect = fake_publish
+
+        main.check_for_removed_stores([])  # no current shops -> "999" is deprecated
+
+        for topic in ("homeassistant/sensor/toogoodtogo_999/state", "homeassistant/sensor/toogoodtogo_999/attr"):
+            assert retained[topic] is True
+            assert published[topic] is None  # empty payload clears the retained message
+    finally:
+        settings["data_dir"] = original_data_dir


### PR DESCRIPTION
### Symptom
A freshly discovered store sensor shows **`unknown`** for its portions until the next poll cycle.

### Cause
The bridge publishes the state (`{"stock": N}`) **non-retained**, immediately after the discovery config. HA receives the config, then *asynchronously* creates the entity and subscribes to the state topic — by which point the non-retained state message is already gone, so HA has no value until the next poll re-publishes it.

### Fix
All state/attribute publishes now go through a `publish_state()` helper that sets `retain=True`. Retained messages are redelivered to any client the instant it subscribes, so a newly created entity gets its value immediately. (This is the standard MQTT-discovery pattern and addresses issue #85.)

### Scope (intentionally minimal)
- ✅ Retained: all **state + attribute** messages (store sensors, next/upcoming collection, last-updated).
- ❌ Left non-retained: **discovery configs**, the **removal** message, and the **intense-fetch switch commands**. Retaining *commands* is an anti-pattern; retaining *configs* (for entity persistence across HA restarts) would also require retaining the removal-clear message and changes restart/removal semantics — a deliberate, larger follow-up, not bundled here.

### Tests
`pytest` asserts the store state and attribute topics are published with `retain=True`; `mypy`/`ruff` green. Verified empirically that config stays `retain=False` while state/attr are `retain=True`.