### PR TITLE
feat: full broker-reconcile cleanup for orphaned entities (on by default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,14 @@ to format pickup times like _in 2 hours_. E.g. `de` for german, `en_us` for amer
 
 remove items from Home Assistant if they are no longer in the fetched result.
 
+#### `full_cleanup` (optional)
+
+A more thorough version of `cleanup`. Instead of relying on the locally tracked store list
+(which is empty after a fresh install or a wiped data dir), it reconciles against the MQTT
+broker itself: it discovers every store entity the broker still holds and removes any that are
+no longer in your favourites. Runs once shortly after startup and then daily. Disabled by
+default — set to `true` to enable.
+
 #### `data_dir` (optional)
 
 folder to store persistent data. Needed e.g. for `cleanup` feature.

--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ remove items from Home Assistant if they are no longer in the fetched result.
 A more thorough version of `cleanup`. Instead of relying on the locally tracked store list
 (which is empty after a fresh install or a wiped data dir), it reconciles against the MQTT
 broker itself: it discovers every store entity the broker still holds and removes any that are
-no longer in your favourites. Runs once shortly after startup and then daily. Disabled by
-default — set to `true` to enable.
+no longer in your favourites. Runs once shortly after startup and then daily. **Enabled by
+default** — set to `false` to disable.
 
 #### `data_dir` (optional)
 

--- a/toogoodtogo_ha_mqtt_bridge/main.py
+++ b/toogoodtogo_ha_mqtt_bridge/main.py
@@ -594,7 +594,9 @@ def check_for_removed_stores(shops: list[Any]) -> None:
             logger.info(f"Shop {deprecated_item} was not checked, will send remove message")
             # NB: the discovery config lives under the .../toogoodtogo_bridge/<id>/config topic
             # (with the node id); publish an empty retained payload there to remove the entity.
-            result = mqtt_client.publish(f"homeassistant/sensor/toogoodtogo_bridge/{deprecated_item}/config", retain=True)
+            result = mqtt_client.publish(
+                f"homeassistant/sensor/toogoodtogo_bridge/{deprecated_item}/config", retain=True
+            )
             # Clear the now-retained state/attribute topics too, so a removed store leaves no
             # orphan retained message on the broker (an empty retained payload deletes it).
             publish_state(f"homeassistant/sensor/toogoodtogo_{deprecated_item}/state")

--- a/toogoodtogo_ha_mqtt_bridge/main.py
+++ b/toogoodtogo_ha_mqtt_bridge/main.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import random
+import re
 import threading
 import time
 from datetime import datetime, timedelta
@@ -78,6 +79,68 @@ def publish_state(topic: str, payload: str | None = None) -> Any:
     subscribed to its topic (issue #85).
     """
     return mqtt_client.publish(topic, payload, retain=True)
+
+
+CLEANUP_SCAN_SECONDS = 5  # how long to collect retained messages from the broker
+
+
+def full_cleanup(current_item_ids: set[str]) -> None:
+    """Remove Home Assistant entities for stores that are no longer favourites.
+
+    Unlike :func:`check_for_removed_stores` (which only knows stores recorded in
+    ``known_shops.json``), this reconciles against the MQTT broker itself: it discovers every
+    store entity the broker still holds via their retained state topics and clears
+    (config + state + attr) any whose item id is not in ``current_item_ids``. This makes
+    cleanup robust to a fresh add-on install or a wiped data dir, where ``known_shops.json`` is
+    gone. Opt-in via the ``full_cleanup`` setting.
+    """
+    if not current_item_ids:
+        # Never reconcile against an empty list - that would delete every entity.
+        logger.warning("Full cleanup skipped: no current favourites to reconcile against")
+        return
+
+    seen: set[str] = set()
+    store_state_topic = re.compile(r"^homeassistant/sensor/toogoodtogo_(\d+)/state$")
+
+    def on_scan_message(client: Any, userdata: Any, message: Any) -> None:
+        # A numeric id means a store sensor; this structurally excludes the fixed diagnostic
+        # sensors (next_collection / upcoming_orders / last_updated) and the switch.
+        match = store_state_topic.match(message.topic)
+        if match and message.payload:  # retained and non-empty => a live store entity
+            seen.add(match.group(1))
+
+    scanner = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2, client_id="toogoodtogo-cleanup-scan")
+    if settings.mqtt.username:
+        scanner.username_pw_set(username=settings.mqtt.username, password=settings.mqtt.password)
+    scanner.on_message = on_scan_message
+    scanner.connect(host=settings.mqtt.host, port=int(settings.mqtt.port))
+    scanner.loop_start()
+    scanner.subscribe("homeassistant/sensor/+/state")  # retained messages are replayed on subscribe
+    sleep(CLEANUP_SCAN_SECONDS)
+    scanner.loop_stop()
+    scanner.disconnect()
+
+    orphans = seen - current_item_ids
+    for item_id in orphans:
+        logger.info(f"Full cleanup: removing orphaned store {item_id}")
+        # An empty retained payload deletes the retained message and removes the HA entity.
+        mqtt_client.publish(f"homeassistant/sensor/toogoodtogo_bridge/{item_id}/config", retain=True)
+        mqtt_client.publish(f"homeassistant/sensor/toogoodtogo_{item_id}/state", retain=True)
+        mqtt_client.publish(f"homeassistant/sensor/toogoodtogo_{item_id}/attr", retain=True)
+    logger.info(f"Full cleanup finished: removed {len(orphans)} orphan(s), kept {len(seen & current_item_ids)}")
+
+
+def cleanup_loop() -> None:
+    """Run :func:`full_cleanup` once the first favourites fetch has succeeded, then daily."""
+    while not favourite_ids:  # wait for a successful fetch so we reconcile against a real list
+        sleep(30)
+    full_cleanup({str(item_id) for item_id in favourite_ids})
+    while True:
+        now = datetime.now()
+        next_run = croniter("0 4 * * *", now).get_next(datetime)
+        sleep((next_run - now).seconds)
+        if favourite_ids:
+            full_cleanup({str(item_id) for item_id in favourite_ids})
 
 
 def check() -> bool:
@@ -529,7 +592,9 @@ def check_for_removed_stores(shops: list[Any]) -> None:
         deprecated_items = [x for x in known_items if x not in checked_items]
         for deprecated_item in deprecated_items:
             logger.info(f"Shop {deprecated_item} was not checked, will send remove message")
-            result = mqtt_client.publish(f"homeassistant/sensor/toogoodtogo_{deprecated_item}/config")
+            # NB: the discovery config lives under the .../toogoodtogo_bridge/<id>/config topic
+            # (with the node id); publish an empty retained payload there to remove the entity.
+            result = mqtt_client.publish(f"homeassistant/sensor/toogoodtogo_bridge/{deprecated_item}/config", retain=True)
             # Clear the now-retained state/attribute topics too, so a removed store leaves no
             # orphan retained message on the broker (an empty retained payload deletes it).
             publish_state(f"homeassistant/sensor/toogoodtogo_{deprecated_item}/state")
@@ -851,6 +916,10 @@ def start() -> None:
 
     thread = threading.Thread(target=ua_check_loop)
     thread.start()
+
+    if settings.get("full_cleanup"):
+        thread = threading.Thread(target=cleanup_loop)
+        thread.start()
 
 
 if __name__ == "__main__":

--- a/toogoodtogo_ha_mqtt_bridge/main.py
+++ b/toogoodtogo_ha_mqtt_bridge/main.py
@@ -42,6 +42,9 @@ tokens_rev = 2  # in case of tokens.json changes, bump this
 watchdog: Watchdog = None  # type: ignore[assignment]
 watchdog_timeout = 0
 favourite_ids: list[int] = []
+# Item ids from the last *fully successful* publish_stores_data run. The full cleanup
+# reconciles against this snapshot so it never acts on a partially-built favourites list.
+last_successful_favourite_ids: set[str] = set()
 scheduled_jobs: list[Any] = []
 
 DEVICE_INFO = {
@@ -131,16 +134,18 @@ def full_cleanup(current_item_ids: set[str]) -> None:
 
 
 def cleanup_loop() -> None:
-    """Run :func:`full_cleanup` once the first favourites fetch has succeeded, then daily."""
-    while not favourite_ids:  # wait for a successful fetch so we reconcile against a real list
+    """Run :func:`full_cleanup` once the first fetch has succeeded, then daily."""
+    while not last_successful_favourite_ids:  # wait for a trusted favourites snapshot
         sleep(30)
-    full_cleanup({str(item_id) for item_id in favourite_ids})
     while True:
+        try:
+            full_cleanup(set(last_successful_favourite_ids))
+        except Exception:
+            # A transient broker error must not permanently stop the daily cleanup.
+            logger.exception("Full cleanup run failed; will retry on the next schedule")
         now = datetime.now()
         next_run = croniter("0 4 * * *", now).get_next(datetime)
         sleep((next_run - now).seconds)
-        if favourite_ids:
-            full_cleanup({str(item_id) for item_id in favourite_ids})
 
 
 def check() -> bool:
@@ -183,7 +188,7 @@ def check() -> bool:
 
 
 def publish_stores_data(shops: list[Any]) -> bool:
-    global favourite_ids
+    global favourite_ids, last_successful_favourite_ids
     favourite_ids.clear()
 
     for shop in shops:
@@ -271,6 +276,8 @@ def publish_stores_data(shops: list[Any]) -> bool:
             logger.warning("Seems like some message was not transferred successfully.")
             return False
 
+    # Only now, after a fully successful run, record the trusted snapshot for the full cleanup.
+    last_successful_favourite_ids = {str(item_id) for item_id in favourite_ids}
     return True
 
 

--- a/toogoodtogo_ha_mqtt_bridge/main.py
+++ b/toogoodtogo_ha_mqtt_bridge/main.py
@@ -95,7 +95,7 @@ def full_cleanup(current_item_ids: set[str]) -> None:
     store entity the broker still holds via their retained state topics and clears
     (config + state + attr) any whose item id is not in ``current_item_ids``. This makes
     cleanup robust to a fresh add-on install or a wiped data dir, where ``known_shops.json`` is
-    gone. Opt-in via the ``full_cleanup`` setting.
+    gone. On by default; set ``full_cleanup: false`` to disable.
     """
     if not current_item_ids:
         # Never reconcile against an empty list - that would delete every entity.
@@ -926,7 +926,7 @@ def start() -> None:
     thread = threading.Thread(target=ua_check_loop)
     thread.start()
 
-    if settings.get("full_cleanup"):
+    if settings.get("full_cleanup", True):  # on by default; set full_cleanup: false to disable
         thread = threading.Thread(target=cleanup_loop)
         thread.start()
 

--- a/toogoodtogo_ha_mqtt_bridge/tests/test_full_cleanup.py
+++ b/toogoodtogo_ha_mqtt_bridge/tests/test_full_cleanup.py
@@ -35,6 +35,7 @@ topic-check:
 """
 
 STORE_STATE = re.compile(r"^homeassistant/sensor/toogoodtogo_(\d+)/state$")
+STORE_CONFIG = re.compile(r"^homeassistant/sensor/toogoodtogo_bridge/(\d+)/config$")
 
 
 def _free_port() -> int:
@@ -89,6 +90,25 @@ def _scan_store_ids(port: int, seconds: float = 1.0) -> set[str]:
     return seen
 
 
+def _scan_config_ids(port: int, seconds: float = 1.0) -> set[str]:
+    seen: set[str] = set()
+
+    def on_message(client: Any, userdata: Any, message: Any) -> None:
+        match = STORE_CONFIG.match(message.topic)
+        if match and message.payload:
+            seen.add(match.group(1))
+
+    client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2, client_id="verify-config")
+    client.on_message = on_message
+    client.connect("127.0.0.1", port)
+    client.loop_start()
+    client.subscribe("homeassistant/sensor/toogoodtogo_bridge/+/config")
+    time.sleep(seconds)
+    client.loop_stop()
+    client.disconnect()
+    return seen
+
+
 @pytest.fixture
 def broker(tmp_path: Path) -> Iterator[int]:
     config = tmp_path / "amqtt.yaml"
@@ -114,17 +134,25 @@ def broker(tmp_path: Path) -> Iterator[int]:
 def test_full_cleanup_removes_orphans_against_real_broker(broker: int, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(main, "CLEANUP_SCAN_SECONDS", 1)
     original_mqtt = settings.get("mqtt")
+    original_client = main.mqtt_client
     settings["mqtt"] = {"host": "127.0.0.1", "port": broker, "username": "", "password": ""}
 
-    seeder = _connected_client(broker, "seeder")
-    main.mqtt_client = _connected_client(broker, "bridge")
+    seeder = None
+    bridge = None
     try:
-        # one active favourite, two orphans, and two non-store diagnostic sensors - all retained
+        seeder = _connected_client(broker, "seeder")
+        bridge = _connected_client(broker, "bridge")
+        main.mqtt_client = bridge
+
+        # retained state for an active favourite, two orphans, and two non-store diagnostic sensors
         seeder.publish("homeassistant/sensor/toogoodtogo_111/state", '{"stock": 3}', retain=True)
         seeder.publish("homeassistant/sensor/toogoodtogo_222/state", '{"stock": 0}', retain=True)
         seeder.publish("homeassistant/sensor/toogoodtogo_333/state", '{"stock": 1}', retain=True)
         seeder.publish("homeassistant/sensor/toogoodtogo_next_collection/state", "x", retain=True)
         seeder.publish("homeassistant/sensor/toogoodtogo_last_updated/state", "x", retain=True)
+        # retained discovery configs for the orphans, to verify the config (HA entity) is cleared too
+        seeder.publish("homeassistant/sensor/toogoodtogo_bridge/222/config", '{"name": "o222"}', retain=True)
+        seeder.publish("homeassistant/sensor/toogoodtogo_bridge/333/config", '{"name": "o333"}', retain=True)
         time.sleep(0.5)
 
         main.full_cleanup({"111"})  # only 111 is still a favourite
@@ -132,9 +160,14 @@ def test_full_cleanup_removes_orphans_against_real_broker(broker: int, monkeypat
 
         # 222/333 cleared; 111 kept; the diagnostic sensors never match the numeric-id filter
         assert _scan_store_ids(broker) == {"111"}
+        # the orphans' discovery configs are cleared too, so HA removes the entities
+        assert _scan_config_ids(broker) == set()
     finally:
-        seeder.loop_stop()
-        seeder.disconnect()
-        main.mqtt_client.loop_stop()
-        main.mqtt_client.disconnect()
+        if seeder is not None:
+            seeder.loop_stop()
+            seeder.disconnect()
+        if bridge is not None:
+            bridge.loop_stop()
+            bridge.disconnect()
+        main.mqtt_client = original_client
         settings["mqtt"] = original_mqtt

--- a/toogoodtogo_ha_mqtt_bridge/tests/test_full_cleanup.py
+++ b/toogoodtogo_ha_mqtt_bridge/tests/test_full_cleanup.py
@@ -1,0 +1,140 @@
+"""Integration test for full_cleanup against a real MQTT broker.
+
+amqtt cannot be a locked dev dependency (its CLI caps click<8.2, conflicting with the
+project's click pin), so the broker is run in an isolated environment via `uvx`. The test
+skips gracefully if uv/uvx or the network is unavailable, so it never hard-breaks CI.
+"""
+
+import re
+import shutil
+import socket
+import subprocess
+import time
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import paho.mqtt.client as mqtt
+import pytest
+
+from toogoodtogo_ha_mqtt_bridge import main
+from toogoodtogo_ha_mqtt_bridge.config import settings
+
+BROKER_CONFIG = """\
+listeners:
+  default:
+    type: tcp
+    bind: 127.0.0.1:{port}
+sys_interval: 0
+auth:
+  allow-anonymous: true
+  plugins:
+    - auth_anonymous
+topic-check:
+  enabled: false
+"""
+
+STORE_STATE = re.compile(r"^homeassistant/sensor/toogoodtogo_(\d+)/state$")
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _wait_for_port(port: int, timeout: float = 20.0) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.5):
+                return True
+        except OSError:
+            time.sleep(0.2)
+    return False
+
+
+def _broker_command(config_path: Path) -> list[str] | None:
+    base = ["--from", "amqtt==0.11.3", "amqtt", "-c", str(config_path)]
+    if shutil.which("uvx"):
+        return ["uvx", *base]
+    if shutil.which("uv"):
+        return ["uv", "tool", "run", *base]
+    return None
+
+
+def _connected_client(port: int, client_id: str) -> Any:
+    client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2, client_id=client_id)
+    client.connect("127.0.0.1", port)
+    client.loop_start()
+    return client
+
+
+def _scan_store_ids(port: int, seconds: float = 1.0) -> set[str]:
+    seen: set[str] = set()
+
+    def on_message(client: Any, userdata: Any, message: Any) -> None:
+        match = STORE_STATE.match(message.topic)
+        if match and message.payload:
+            seen.add(match.group(1))
+
+    client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2, client_id="verify")
+    client.on_message = on_message
+    client.connect("127.0.0.1", port)
+    client.loop_start()
+    client.subscribe("homeassistant/sensor/+/state")
+    time.sleep(seconds)
+    client.loop_stop()
+    client.disconnect()
+    return seen
+
+
+@pytest.fixture
+def broker(tmp_path: Path) -> Iterator[int]:
+    config = tmp_path / "amqtt.yaml"
+    port = _free_port()
+    config.write_text(BROKER_CONFIG.format(port=port))
+    command = _broker_command(config)
+    if command is None:
+        pytest.skip("uv/uvx not available to run the amqtt broker")
+    # `command` is a fixed list (uvx/uv + pinned amqtt + a temp config path); no untrusted input.
+    proc = subprocess.Popen(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)  # noqa: S603
+    try:
+        if not _wait_for_port(port):
+            pytest.skip("amqtt broker did not start (offline or uvx fetch failed)")
+        yield port
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+def test_full_cleanup_removes_orphans_against_real_broker(broker: int, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(main, "CLEANUP_SCAN_SECONDS", 1)
+    original_mqtt = settings.get("mqtt")
+    settings["mqtt"] = {"host": "127.0.0.1", "port": broker, "username": "", "password": ""}
+
+    seeder = _connected_client(broker, "seeder")
+    main.mqtt_client = _connected_client(broker, "bridge")
+    try:
+        # one active favourite, two orphans, and two non-store diagnostic sensors - all retained
+        seeder.publish("homeassistant/sensor/toogoodtogo_111/state", '{"stock": 3}', retain=True)
+        seeder.publish("homeassistant/sensor/toogoodtogo_222/state", '{"stock": 0}', retain=True)
+        seeder.publish("homeassistant/sensor/toogoodtogo_333/state", '{"stock": 1}', retain=True)
+        seeder.publish("homeassistant/sensor/toogoodtogo_next_collection/state", "x", retain=True)
+        seeder.publish("homeassistant/sensor/toogoodtogo_last_updated/state", "x", retain=True)
+        time.sleep(0.5)
+
+        main.full_cleanup({"111"})  # only 111 is still a favourite
+        time.sleep(0.5)
+
+        # 222/333 cleared; 111 kept; the diagnostic sensors never match the numeric-id filter
+        assert _scan_store_ids(broker) == {"111"}
+    finally:
+        seeder.loop_stop()
+        seeder.disconnect()
+        main.mqtt_client.loop_stop()
+        main.mqtt_client.disconnect()
+        settings["mqtt"] = original_mqtt


### PR DESCRIPTION
Removes Home Assistant entities for stores that are no longer favourites — robustly, by reconciling against the MQTT broker itself.

### Why
`check_for_removed_stores` only knows stores recorded in `known_shops.json`. After a fresh add-on install, a wiped data dir, or un-favouriting a store while the bridge was off, the bridge has no memory of those stores, so their HA entities + (now-retained) MQTT messages linger with no cleanup path.

### What
`full_cleanup` subscribes to the retained `…/state` topics to discover every store entity the broker still holds, and clears `config` + `state` + `attr` for any whose item id is no longer a favourite. **On by default** (runs once after the first successful fetch, then daily); set `full_cleanup: false` to disable.

### Safety
- Reconciles only against the **last _successful_ fetch** snapshot — never a partially-built favourites list.
- A **numeric-id filter** structurally excludes the diagnostic sensors (`next_collection`/`upcoming_orders`/`last_updated`) and the switch — they cannot be deleted.
- `cleanup_loop` wraps each run in try/except, so a transient broker error can't permanently stop the daily schedule.
- Also fixes a **pre-existing bug**: removal published to `…/toogoodtogo_<id>/config` but the discovery config lives at `…/toogoodtogo_bridge/<id>/config` — so removal never actually removed the HA entity. Now corrected.

### Tests
Validated against a **real MQTT broker**: the integration test runs `amqtt` via `uvx` in an isolated env (it can't be a locked dev dep — its CLI caps `click<8.2` vs the project's pin) and asserts the orphans' `state` **and** `config` are cleared while the active favourite + diagnostic sensors survive. Confirmed **executing (not skipped) on GitHub CI** across 3.12/3.13/3.14. `mypy`/`ruff` green; `click` and `uv.lock` untouched.

Validated end-to-end on a real Home Assistant instance.