### PR TITLE
feat: configurable MQTT topics + Home Assistant toggle + raw mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,26 @@ default** — set to `false` to disable.
 
 folder to store persistent data. Needed e.g. for `cleanup` feature.
 
+#### Topic configuration (optional)
+
+By default all topics live under `homeassistant/` so Home Assistant auto-discovers everything.
+These optional settings let you decouple the data topics from the discovery prefix or use the
+bridge without Home Assistant at all. All default to the historical topics, so existing setups
+are unaffected.
+
+```json
+{
+  "mqtt": { "base": "homeassistant/sensor" },
+  "homeassistant": { "enabled": true, "discovery_prefix": "homeassistant" },
+  "raw": false
+}
+```
+
+- `mqtt.base` — base topic for the sensor **state/attribute** (and `raw`) data, e.g. set to `tgtg` to publish state under `tgtg/toogoodtogo_<id>/state`. Default `homeassistant/sensor`.
+- `homeassistant.enabled` — set to `false` to stop publishing Home Assistant discovery configs (and the intense-fetch switch). State/attribute/raw data is still published, for non-HA MQTT consumers. Default `true`.
+- `homeassistant.discovery_prefix` — Home Assistant's MQTT discovery prefix, if you've customised it in HA. Default `homeassistant`.
+- `raw` — also publish the full, unprocessed store payload to `<mqtt.base>/toogoodtogo_<id>/raw`. Default `false`.
+
 And start with the mounted settings file, e.g. for macOS:
 
 ```bash

--- a/toogoodtogo_ha_mqtt_bridge/main.py
+++ b/toogoodtogo_ha_mqtt_bridge/main.py
@@ -238,9 +238,7 @@ def publish_stores_data(shops: list[Any]) -> bool:
 
         result_raw = None
         if raw_enabled():
-            result_raw = mqtt_client.publish(
-                f"{data_base()}/toogoodtogo_{item_id}/raw", json.dumps(shop), retain=True
-            )
+            result_raw = mqtt_client.publish(f"{data_base()}/toogoodtogo_{item_id}/raw", json.dumps(shop), retain=True)
 
         # Autodiscover (only when Home Assistant discovery is enabled)
         result_ad = None

--- a/toogoodtogo_ha_mqtt_bridge/main.py
+++ b/toogoodtogo_ha_mqtt_bridge/main.py
@@ -59,17 +59,20 @@ DEVICE_INFO = {
 # setups are unaffected; read lazily so settings changes/tests take effect at call time. ---
 def data_base() -> str:
     """Base topic for the sensor state/attribute/raw data topics."""
-    return str((settings.get("mqtt") or {}).get("base", "homeassistant/sensor"))
+    value = (settings.get("mqtt") or {}).get("base")
+    return "homeassistant/sensor" if value is None else str(value)
 
 
 def discovery_prefix() -> str:
     """Home Assistant MQTT discovery prefix (where ``.../config`` topics live)."""
-    return str((settings.get("homeassistant") or {}).get("discovery_prefix", "homeassistant"))
+    value = (settings.get("homeassistant") or {}).get("discovery_prefix")
+    return "homeassistant" if value is None else str(value)
 
 
 def homeassistant_enabled() -> bool:
     """Whether to publish Home Assistant discovery configs (and the intense-fetch switch)."""
-    return bool((settings.get("homeassistant") or {}).get("enabled", True))
+    value = (settings.get("homeassistant") or {}).get("enabled")
+    return True if value is None else bool(value)
 
 
 def raw_enabled() -> bool:
@@ -233,8 +236,11 @@ def publish_stores_data(shops: list[Any]) -> bool:
 
         logger.debug(f"Pushing message for {shop['display_name']} // {item_id}")
 
+        result_raw = None
         if raw_enabled():
-            mqtt_client.publish(f"{data_base()}/toogoodtogo_{item_id}/raw", json.dumps(shop), retain=True)
+            result_raw = mqtt_client.publish(
+                f"{data_base()}/toogoodtogo_{item_id}/raw", json.dumps(shop), retain=True
+            )
 
         # Autodiscover (only when Home Assistant discovery is enabled)
         result_ad = None
@@ -297,6 +303,8 @@ def publish_stores_data(shops: list[Any]) -> bool:
         results = [result_state, result_attrs]
         if result_ad is not None:  # None when Home Assistant discovery is disabled
             results.append(result_ad)
+        if result_raw is not None:  # None when raw publishing is disabled
+            results.append(result_raw)
         logger.debug(
             f"Message published: Autodiscover: {result_ad is not None and result_ad.rc == mqtt.MQTT_ERR_SUCCESS}, "
             f"State: {bool(result_state.rc == mqtt.MQTT_ERR_SUCCESS)}, "
@@ -940,10 +948,13 @@ def start() -> None:
     mqtt_client.on_disconnect = on_disconnect
     mqtt_client.on_connect = on_connect
 
-    if homeassistant_enabled() and "intense_fetch" in settings.tgtg:
+    if "intense_fetch" in settings.tgtg:
+        # The /set topic is the command channel for both the HA switch and auto intense-fetch,
+        # so subscribe regardless of HA; only the discovery switch entity itself is HA-gated.
         mqtt_client.subscribe(f"{discovery_prefix()}/switch/toogoodtogo_intense_fetch/set")
-        register_fetch_sensor()
         mqtt_client.on_message = on_message
+        if homeassistant_enabled():
+            register_fetch_sensor()
 
     mqtt_client.loop_start()
     event = threading.Event()

--- a/toogoodtogo_ha_mqtt_bridge/main.py
+++ b/toogoodtogo_ha_mqtt_bridge/main.py
@@ -55,6 +55,28 @@ DEVICE_INFO = {
 }
 
 
+# --- Configurable MQTT topics (see #131). All default to the historical topics, so existing
+# setups are unaffected; read lazily so settings changes/tests take effect at call time. ---
+def data_base() -> str:
+    """Base topic for the sensor state/attribute/raw data topics."""
+    return str((settings.get("mqtt") or {}).get("base", "homeassistant/sensor"))
+
+
+def discovery_prefix() -> str:
+    """Home Assistant MQTT discovery prefix (where ``.../config`` topics live)."""
+    return str((settings.get("homeassistant") or {}).get("discovery_prefix", "homeassistant"))
+
+
+def homeassistant_enabled() -> bool:
+    """Whether to publish Home Assistant discovery configs (and the intense-fetch switch)."""
+    return bool((settings.get("homeassistant") or {}).get("enabled", True))
+
+
+def raw_enabled() -> bool:
+    """Whether to also publish the full raw store payload (for non-HA MQTT consumers)."""
+    return bool(settings.get("raw", False))
+
+
 def entity_naming(default_entity_id: str, name: str) -> dict[str, Any]:
     """Naming keys for an MQTT discovery payload.
 
@@ -103,7 +125,7 @@ def full_cleanup(current_item_ids: set[str]) -> None:
         return
 
     seen: set[str] = set()
-    store_state_topic = re.compile(r"^homeassistant/sensor/toogoodtogo_(\d+)/state$")
+    store_state_topic = re.compile(rf"^{re.escape(data_base())}/toogoodtogo_(\d+)/state$")
 
     def on_scan_message(client: Any, userdata: Any, message: Any) -> None:
         # A numeric id means a store sensor; this structurally excludes the fixed diagnostic
@@ -118,7 +140,7 @@ def full_cleanup(current_item_ids: set[str]) -> None:
     scanner.on_message = on_scan_message
     scanner.connect(host=settings.mqtt.host, port=int(settings.mqtt.port))
     scanner.loop_start()
-    scanner.subscribe("homeassistant/sensor/+/state")  # retained messages are replayed on subscribe
+    scanner.subscribe(f"{data_base()}/+/state")  # retained messages are replayed on subscribe
     sleep(CLEANUP_SCAN_SECONDS)
     scanner.loop_stop()
     scanner.disconnect()
@@ -127,9 +149,9 @@ def full_cleanup(current_item_ids: set[str]) -> None:
     for item_id in orphans:
         logger.info(f"Full cleanup: removing orphaned store {item_id}")
         # An empty retained payload deletes the retained message and removes the HA entity.
-        mqtt_client.publish(f"homeassistant/sensor/toogoodtogo_bridge/{item_id}/config", retain=True)
-        mqtt_client.publish(f"homeassistant/sensor/toogoodtogo_{item_id}/state", retain=True)
-        mqtt_client.publish(f"homeassistant/sensor/toogoodtogo_{item_id}/attr", retain=True)
+        mqtt_client.publish(f"{discovery_prefix()}/sensor/toogoodtogo_bridge/{item_id}/config", retain=True)
+        mqtt_client.publish(f"{data_base()}/toogoodtogo_{item_id}/state", retain=True)
+        mqtt_client.publish(f"{data_base()}/toogoodtogo_{item_id}/attr", retain=True)
     logger.info(f"Full cleanup finished: removed {len(orphans)} orphan(s), kept {len(seen & current_item_ids)}")
 
 
@@ -166,16 +188,18 @@ def check() -> bool:
     if settings.get("cleanup"):
         check_for_removed_stores(shops)
 
-    try:
-        active_orders = tgtg_client.get_active()
-        if not publish_orders_data(active_orders):
+    # Orders / last-updated are Home Assistant diagnostic sensors; skip them when HA is disabled.
+    if homeassistant_enabled():
+        try:
+            active_orders = tgtg_client.get_active()
+            if not publish_orders_data(active_orders):
+                return False
+        except Exception:
+            logging.exception("Error fetching active orders")
             return False
-    except Exception:
-        logging.exception("Error fetching active orders")
-        return False
 
-    if not publish_last_updated():
-        return False
+        if not publish_last_updated():
+            return False
 
     # Start automatic intense fetch watchdog
     if first_run and settings.get("enable_auto_intense_fetch"):
@@ -185,6 +209,17 @@ def check() -> bool:
     first_run = False
 
     return True
+
+
+def extract_price(item: dict[str, Any]) -> float:
+    """Return the item price in major units, trying the known price fields in order."""
+    for key in ("price", "item_price", "price_including_taxes"):
+        if item.get(key):
+            return float(item[key]["minor_units"] / pow(10, item[key]["decimals"]))
+    logger.error("Can't find price")
+    logger.debug("Content of item obj:")
+    logger.debug(json.dumps(item))
+    return 0
 
 
 def publish_stores_data(shops: list[Any]) -> bool:
@@ -198,40 +233,32 @@ def publish_stores_data(shops: list[Any]) -> bool:
 
         logger.debug(f"Pushing message for {shop['display_name']} // {item_id}")
 
-        # Autodiscover
-        result_ad = mqtt_client.publish(
-            f"homeassistant/sensor/toogoodtogo_bridge/{item_id}/config",
-            json.dumps({
-                **entity_naming(f"sensor.toogoodtogo_{item_id}", shop["display_name"]),
-                "icon": "mdi:food" if stock > 0 else "mdi:food-off",
-                "state_topic": f"homeassistant/sensor/toogoodtogo_{item_id}/state",
-                "json_attributes_topic": f"homeassistant/sensor/toogoodtogo_{item_id}/attr",
-                "unit_of_measurement": "portions",
-                "value_template": "{{ value_json.stock }}",
-                "device": DEVICE_INFO,
-                "unique_id": f"toogoodtogo_{item_id}",
-            }),
-        )
+        if raw_enabled():
+            mqtt_client.publish(f"{data_base()}/toogoodtogo_{item_id}/raw", json.dumps(shop), retain=True)
+
+        # Autodiscover (only when Home Assistant discovery is enabled)
+        result_ad = None
+        if homeassistant_enabled():
+            result_ad = mqtt_client.publish(
+                f"{discovery_prefix()}/sensor/toogoodtogo_bridge/{item_id}/config",
+                json.dumps({
+                    **entity_naming(f"sensor.toogoodtogo_{item_id}", shop["display_name"]),
+                    "icon": "mdi:food" if stock > 0 else "mdi:food-off",
+                    "state_topic": f"{data_base()}/toogoodtogo_{item_id}/state",
+                    "json_attributes_topic": f"{data_base()}/toogoodtogo_{item_id}/attr",
+                    "unit_of_measurement": "portions",
+                    "value_template": "{{ value_json.stock }}",
+                    "device": DEVICE_INFO,
+                    "unique_id": f"toogoodtogo_{item_id}",
+                }),
+            )
 
         result_state = publish_state(
-            f"homeassistant/sensor/toogoodtogo_{item_id}/state",
+            f"{data_base()}/toogoodtogo_{item_id}/state",
             json.dumps({"stock": stock}),
         )
 
-        # prepare attrs
-        if shop["item"].get("price"):
-            price = shop["item"]["price"]["minor_units"] / pow(10, shop["item"]["price"]["decimals"])
-        elif shop["item"].get("item_price"):
-            price = shop["item"]["item_price"]["minor_units"] / pow(10, shop["item"]["item_price"]["decimals"])
-        elif shop["item"].get("price_including_taxes"):
-            price = shop["item"]["price_including_taxes"]["minor_units"] / pow(
-                10, shop["item"]["price_including_taxes"]["decimals"]
-            )
-        else:
-            logger.error("Can't find price")
-            logger.debug("Content of item obj:")
-            logger.debug(json.dumps(shop["item"]))
-            price = 0
+        price = extract_price(shop["item"])
 
         pickup_start_date = None if not stock else arrow.get(shop["pickup_interval"]["start"]).to(tz=settings.timezone)
         pickup_end_date = None if not stock else arrow.get(shop["pickup_interval"]["end"]).to(tz=settings.timezone)
@@ -255,7 +282,7 @@ def publish_stores_data(shops: list[Any]) -> bool:
                 picture = "https://toogoodtogo.com/images/logo/econ-textless.svg"
 
         result_attrs = publish_state(
-            f"homeassistant/sensor/toogoodtogo_{item_id}/attr",
+            f"{data_base()}/toogoodtogo_{item_id}/attr",
             json.dumps({
                 "price": price,
                 "stock_available": True if stock > 0 else False,
@@ -267,12 +294,15 @@ def publish_stores_data(shops: list[Any]) -> bool:
                 "picture": picture,
             }),
         )
+        results = [result_state, result_attrs]
+        if result_ad is not None:  # None when Home Assistant discovery is disabled
+            results.append(result_ad)
         logger.debug(
-            f"Message published: Autodiscover: {bool(result_ad.rc == mqtt.MQTT_ERR_SUCCESS)}, "
+            f"Message published: Autodiscover: {result_ad is not None and result_ad.rc == mqtt.MQTT_ERR_SUCCESS}, "
             f"State: {bool(result_state.rc == mqtt.MQTT_ERR_SUCCESS)}, "
             f"Attributes: {bool(result_attrs.rc == mqtt.MQTT_ERR_SUCCESS)}"
         )
-        if not result_ad.rc == result_state.rc == result_attrs.rc == mqtt.MQTT_ERR_SUCCESS:
+        if not all(result.rc == mqtt.MQTT_ERR_SUCCESS for result in results):
             logger.warning("Seems like some message was not transferred successfully.")
             return False
 
@@ -286,27 +316,27 @@ def publish_orders_data(active_orders: dict) -> bool:
     has_orders = len(orders) > 0
 
     result_ad = mqtt_client.publish(
-        "homeassistant/sensor/toogoodtogo_next_collection/config",
+        f"{discovery_prefix()}/sensor/toogoodtogo_next_collection/config",
         json.dumps({
             **entity_naming("sensor.toogoodtogo_next_collection", "Next Collection"),
             "icon": "mdi:calendar-clock" if has_orders else "mdi:calendar-remove",
             "device_class": "timestamp",
             "entity_category": "diagnostic",
-            "state_topic": "homeassistant/sensor/toogoodtogo_next_collection/state",
-            "json_attributes_topic": "homeassistant/sensor/toogoodtogo_next_collection/attr",
+            "state_topic": f"{data_base()}/toogoodtogo_next_collection/state",
+            "json_attributes_topic": f"{data_base()}/toogoodtogo_next_collection/attr",
             "device": DEVICE_INFO,
             "unique_id": "toogoodtogo_next_collection",
         }),
     )
 
     result_ad_count = mqtt_client.publish(
-        "homeassistant/sensor/toogoodtogo_upcoming_orders/config",
+        f"{discovery_prefix()}/sensor/toogoodtogo_upcoming_orders/config",
         json.dumps({
             **entity_naming("sensor.toogoodtogo_upcoming_orders", "Upcoming Orders"),
             "icon": "mdi:cart" if has_orders else "mdi:cart-off",
             "entity_category": "diagnostic",
-            "state_topic": "homeassistant/sensor/toogoodtogo_upcoming_orders/state",
-            "json_attributes_topic": "homeassistant/sensor/toogoodtogo_upcoming_orders/attr",
+            "state_topic": f"{data_base()}/toogoodtogo_upcoming_orders/state",
+            "json_attributes_topic": f"{data_base()}/toogoodtogo_upcoming_orders/attr",
             "unit_of_measurement": "orders",
             "device": DEVICE_INFO,
             "unique_id": "toogoodtogo_upcoming_orders",
@@ -321,12 +351,12 @@ def publish_orders_data(active_orders: dict) -> bool:
         pickup_date_arrow = arrow.get(pickup_date).to(tz=settings.timezone)
 
         result_state = publish_state(
-            "homeassistant/sensor/toogoodtogo_next_collection/state",
+            f"{data_base()}/toogoodtogo_next_collection/state",
             pickup_date_arrow.isoformat(),
         )
 
         result_attrs = publish_state(
-            "homeassistant/sensor/toogoodtogo_next_collection/attr",
+            f"{data_base()}/toogoodtogo_next_collection/attr",
             json.dumps({
                 "order_id": next_order["order_id"],
                 "store_name": next_order["store_name"],
@@ -345,7 +375,7 @@ def publish_orders_data(active_orders: dict) -> bool:
         )
 
         result_state_count = publish_state(
-            "homeassistant/sensor/toogoodtogo_upcoming_orders/state",
+            f"{data_base()}/toogoodtogo_upcoming_orders/state",
             str(len(orders)),
         )
 
@@ -362,7 +392,7 @@ def publish_orders_data(active_orders: dict) -> bool:
         ]
 
         result_attrs_count = publish_state(
-            "homeassistant/sensor/toogoodtogo_upcoming_orders/attr",
+            f"{data_base()}/toogoodtogo_upcoming_orders/attr",
             json.dumps({"orders": orders_summary}),
         )
 
@@ -391,19 +421,19 @@ def publish_orders_data(active_orders: dict) -> bool:
 
     else:
         result_state = publish_state(
-            "homeassistant/sensor/toogoodtogo_next_collection/state",
+            f"{data_base()}/toogoodtogo_next_collection/state",
             "null",
         )
         result_attrs = publish_state(
-            "homeassistant/sensor/toogoodtogo_next_collection/attr",
+            f"{data_base()}/toogoodtogo_next_collection/attr",
             json.dumps({}),
         )
         result_state_count = publish_state(
-            "homeassistant/sensor/toogoodtogo_upcoming_orders/state",
+            f"{data_base()}/toogoodtogo_upcoming_orders/state",
             "0",
         )
         result_attrs_count = publish_state(
-            "homeassistant/sensor/toogoodtogo_upcoming_orders/attr",
+            f"{data_base()}/toogoodtogo_upcoming_orders/attr",
             json.dumps({"orders": []}),
         )
 
@@ -437,20 +467,20 @@ def publish_last_updated() -> bool:
     current_time = arrow.now().to(tz=settings.timezone)
 
     result_ad = mqtt_client.publish(
-        "homeassistant/sensor/toogoodtogo_last_updated/config",
+        f"{discovery_prefix()}/sensor/toogoodtogo_last_updated/config",
         json.dumps({
             **entity_naming("sensor.toogoodtogo_last_updated", "Last Updated"),
             "icon": "mdi:clock-outline",
             "device_class": "timestamp",
             "entity_category": "diagnostic",
-            "state_topic": "homeassistant/sensor/toogoodtogo_last_updated/state",
+            "state_topic": f"{data_base()}/toogoodtogo_last_updated/state",
             "device": DEVICE_INFO,
             "unique_id": "toogoodtogo_last_updated",
         }),
     )
 
     result_state = publish_state(
-        "homeassistant/sensor/toogoodtogo_last_updated/state",
+        f"{data_base()}/toogoodtogo_last_updated/state",
         current_time.isoformat(),
     )
 
@@ -602,12 +632,12 @@ def check_for_removed_stores(shops: list[Any]) -> None:
             # NB: the discovery config lives under the .../toogoodtogo_bridge/<id>/config topic
             # (with the node id); publish an empty retained payload there to remove the entity.
             result = mqtt_client.publish(
-                f"homeassistant/sensor/toogoodtogo_bridge/{deprecated_item}/config", retain=True
+                f"{discovery_prefix()}/sensor/toogoodtogo_bridge/{deprecated_item}/config", retain=True
             )
             # Clear the now-retained state/attribute topics too, so a removed store leaves no
             # orphan retained message on the broker (an empty retained payload deletes it).
-            publish_state(f"homeassistant/sensor/toogoodtogo_{deprecated_item}/state")
-            publish_state(f"homeassistant/sensor/toogoodtogo_{deprecated_item}/attr")
+            publish_state(f"{data_base()}/toogoodtogo_{deprecated_item}/state")
+            publish_state(f"{data_base()}/toogoodtogo_{deprecated_item}/attr")
             logger.debug(f"Message published: Removal: {bool(result.rc == mqtt.MQTT_ERR_SUCCESS)}")
 
     with open(path, "w") as f:
@@ -682,7 +712,7 @@ def next_sales_loop() -> None:
 def trigger_intense_fetch() -> Any:
     logger.info("Running automatic intense fetch!")
     mqtt_client.publish(
-        "homeassistant/switch/toogoodtogo_intense_fetch/set",
+        f"{discovery_prefix()}/switch/toogoodtogo_intense_fetch/set",
         "ON",
     )
     return schedule.CancelJob
@@ -815,7 +845,7 @@ def intense_fetch() -> None:
         return
 
     mqtt_client.publish(
-        "homeassistant/switch/toogoodtogo_intense_fetch/state",
+        f"{discovery_prefix()}/switch/toogoodtogo_intense_fetch/state",
         "ON",
     )
 
@@ -834,7 +864,7 @@ def intense_fetch() -> None:
     intense_fetch_thread = None
 
     mqtt_client.publish(
-        "homeassistant/switch/toogoodtogo_intense_fetch/state",
+        f"{discovery_prefix()}/switch/toogoodtogo_intense_fetch/state",
         "OFF",
     )
 
@@ -857,7 +887,7 @@ def on_message(client: Any, userdata: Any, message: Any) -> None:
                 intense_fetch_thread.do_run = False  # type: ignore[attr-defined]
                 logger.info("Intense fetch is stopped in the next cycle.")
                 mqtt_client.publish(
-                    "homeassistant/switch/toogoodtogo_intense_fetch/state",
+                    f"{discovery_prefix()}/switch/toogoodtogo_intense_fetch/state",
                     "OFF",
                 )
             else:
@@ -866,19 +896,19 @@ def on_message(client: Any, userdata: Any, message: Any) -> None:
 
 def register_fetch_sensor() -> None:
     mqtt_client.publish(
-        "homeassistant/switch/toogoodtogo_bridge/intense_fetch/config",
+        f"{discovery_prefix()}/switch/toogoodtogo_bridge/intense_fetch/config",
         json.dumps({
             **entity_naming("switch.toogoodtogo_intense_fetch_switch", "Intense fetch"),
             "icon": "mdi:fast-forward",
-            "state_topic": "homeassistant/switch/toogoodtogo_intense_fetch/state",
-            "command_topic": "homeassistant/switch/toogoodtogo_intense_fetch/set",
+            "state_topic": f"{discovery_prefix()}/switch/toogoodtogo_intense_fetch/state",
+            "command_topic": f"{discovery_prefix()}/switch/toogoodtogo_intense_fetch/set",
             "device": DEVICE_INFO,
             "unique_id": "toogoodtogo_intense_fetch_switch",
         }),
     )
 
     mqtt_client.publish(
-        "homeassistant/switch/toogoodtogo_intense_fetch/state",
+        f"{discovery_prefix()}/switch/toogoodtogo_intense_fetch/state",
         "OFF",
     )
 
@@ -910,8 +940,8 @@ def start() -> None:
     mqtt_client.on_disconnect = on_disconnect
     mqtt_client.on_connect = on_connect
 
-    if "intense_fetch" in settings.tgtg:
-        mqtt_client.subscribe("homeassistant/switch/toogoodtogo_intense_fetch/set")
+    if homeassistant_enabled() and "intense_fetch" in settings.tgtg:
+        mqtt_client.subscribe(f"{discovery_prefix()}/switch/toogoodtogo_intense_fetch/set")
         register_fetch_sensor()
         mqtt_client.on_message = on_message
 

--- a/toogoodtogo_ha_mqtt_bridge/tests/test_publish.py
+++ b/toogoodtogo_ha_mqtt_bridge/tests/test_publish.py
@@ -115,3 +115,54 @@ def test_check_for_removed_stores_clears_retained(tmp_path: Path) -> None:
             assert published[topic] is None  # empty payload clears the retained message
     finally:
         settings["data_dir"] = original_data_dir
+
+
+@pytest.fixture
+def _topic_settings() -> Generator[None, None, None]:
+    keys = ("mqtt", "homeassistant", "raw")
+    original = {key: settings.get(key) for key in keys}
+    yield
+    for key, value in original.items():
+        settings[key] = value
+
+
+def _publish_one_store() -> dict[str, str]:
+    published: dict[str, str] = {}
+
+    def fake_publish(topic: str, payload: str | None = None, retain: bool = False) -> MagicMock:
+        published[topic] = payload  # type: ignore[assignment]
+        return MagicMock(rc=mqtt.MQTT_ERR_SUCCESS)
+
+    main.mqtt_client = MagicMock()
+    main.mqtt_client.publish.side_effect = fake_publish
+    assert main.publish_stores_data([_fake_shop(stock=3)]) is True
+    return published
+
+
+def test_publish_stores_data_custom_topics(_settings_env: None, _topic_settings: None) -> None:
+    # Configurable topics (#131): data topics use mqtt.base, discovery uses discovery_prefix,
+    # and raw=true publishes the full payload. Defaults reproduce the historical topics.
+    settings["mqtt"] = {"base": "tgtg/data"}
+    settings["homeassistant"] = {"enabled": True, "discovery_prefix": "ha"}
+    settings["raw"] = True
+
+    published = _publish_one_store()
+
+    assert "tgtg/data/toogoodtogo_123/state" in published
+    assert "tgtg/data/toogoodtogo_123/attr" in published
+    assert "tgtg/data/toogoodtogo_123/raw" in published
+    config = json.loads(published["ha/sensor/toogoodtogo_bridge/123/config"])
+    assert config["state_topic"] == "tgtg/data/toogoodtogo_123/state"  # config points at the data base
+
+
+def test_publish_stores_data_homeassistant_disabled(_settings_env: None, _topic_settings: None) -> None:
+    # With HA disabled, no discovery config is published, but state + raw still are (non-HA use).
+    settings["mqtt"] = {}
+    settings["homeassistant"] = {"enabled": False}
+    settings["raw"] = True
+
+    published = _publish_one_store()
+
+    assert not any(topic.endswith("/config") for topic in published)
+    assert "homeassistant/sensor/toogoodtogo_123/state" in published
+    assert "homeassistant/sensor/toogoodtogo_123/raw" in published


### PR DESCRIPTION
Reimplements the intent of #132 on current `main`, **backward-compatibly**. Supersedes #132 (which was 3 years stale and unmergeable) and addresses #131.

### What
All MQTT topic strings now derive from small settings accessors that **default to today's exact topics** — so existing installs are unaffected. New opt-in settings:

| Setting | Default | Effect |
|---|---|---|
| `mqtt.base` | `homeassistant/sensor` | base for sensor **state/attr/raw** data topics — decouple them from the discovery prefix (#131) |
| `homeassistant.enabled` | `true` | `false` skips discovery configs + the intense-fetch switch; state/attr/raw still published for non-HA consumers |
| `homeassistant.discovery_prefix` | `homeassistant` | HA's discovery prefix, if customised |
| `raw` | `false` | also publish the full store payload to `<base>/toogoodtogo_<id>/raw` |

### Deliberately *not* copied from #132
- his `…/favorites/<id>` topic restructure and re-added `object_id` — would re-break every user's entity IDs (undoing the recent stabilization).
- his `name_prefix` — superseded by the `has_entity_name` brand-free naming.
- his stray `bdbogjoe/…` Docker tag.

### Notes
- Accessors read settings **lazily** (not at import) so runtime/tests see current values, and tolerate `null` (`or {}`).
- HA-only publishers (orders/last-updated diagnostics, switch) are gated at their call sites; `publish_stores_data` gates only the discovery config inline (state/raw always run).
- Extracted `extract_price()` to keep `publish_stores_data` under the complexity limit.

### Tests
New tests cover custom `mqtt.base`/`discovery_prefix`, `raw`, and `homeassistant.enabled: false`. The **existing** tests (unchanged, using defaults) pass — proving backward-compat. `mypy`/`ruff` green, `uv.lock` untouched.