### PR TITLE
Point the ko-fi badge at a URL that still resolves

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TooGoodToGo Home Assistant Mqtt Bridge
 
-[![ko-fi](https://www.ko-fi.com/img/donate_sm.png)](https://ko-fi.com/MaxWinterstein)
+<a href='https://ko-fi.com/MaxWinterstein' target='_blank'><img height='36' style='border:0px;height:36px;' src='https://storage.ko-fi.com/cdn/kofi6.png?v=6' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a>
 
 Small python tool to forward stock of you favourite stores to Home Assistant via MQTT.
 


### PR DESCRIPTION
The ko-fi badge under the heading has been rendering as a broken image:

```
https://www.ko-fi.com/img/donate_sm.png   →  404
```

Ko-fi retired the `www.ko-fi.com/img/` path. The button itself is fine, only that URL is gone.

This swaps in the same button [homeassistant-addons](https://github.com/MaxWinterstein/homeassistant-addons) already uses and which resolves today:

```
https://storage.ko-fi.com/cdn/kofi6.png?v=6   →  200
```

Kept in the HTML form with `height='36'` because the source image is 580x146 and would otherwise render full width. Same markup as the other repo, so the two now match.

`.github/FUNDING.yml` and the Sponsor button are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)