### PR TITLE
chore: add a bug report form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,45 @@
+name: Bug report
+description: Something is not working as expected
+labels: ["bug"]
+body:
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: How are you running it?
+      options:
+        - Home Assistant add-on
+        - Docker
+        - Native
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Add-on version, Docker image tag or git commit. E.g. `3.5.0.0` for the add-on, `3.6.0` for Docker.
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you expect, and what happened instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: Relevant log output. Gets formatted automatically, no backticks needed.
+      render: shell
+
+  - type: checkboxes
+    id: no-credentials
+    attributes:
+      label: Credentials
+      options:
+        - label: I removed my TooGoodToGo email, tokens, cookies and MQTT password from the logs and config I pasted above.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Home Assistant add-on repository
+    url: https://github.com/MaxWinterstein/homeassistant-addons/issues
+    about: Problems with installing or updating the add-on itself belong here.
+  - name: TooGoodToGo API library (tgtg)
+    url: https://github.com/ahivert/tgtg-python/issues
+    about: Login problems, captchas and API errors usually come from the underlying library.


### PR DESCRIPTION
No `.github/ISSUE_TEMPLATE/` exists here today.

### The form asks for

- **how you are running it** — Home Assistant add-on / Docker / Native (matching the three install sections in the README)
- **version**
- what happened
- logs, in a `render: shell` textarea
- a required checkbox: *"I removed my TooGoodToGo email, tokens, cookies and MQTT password from the logs and config I pasted above."*

That last one is the reason this is worth doing at all. This tool holds a TooGoodToGo login and an MQTT password, and people paste raw config and logs into issues without thinking. A checkbox will not catch everything, but it makes the reporter look once before hitting submit.

### config.yml

Two contact links rather than a Discussions tab, which is disabled on this repo (`has_discussions: false`):

- the add-on repository, for problems installing or updating the add-on itself
- [ahivert/tgtg-python](https://github.com/ahivert/tgtg-python), since login failures, captchas and API errors usually originate in the underlying library rather than here

`blank_issues_enabled` stays `true`.

Wording follows your own vocabulary — the README's third install section is headed **Native**, so the dropdown says Native rather than "From source". The version example covers both shapes users actually report (`3.5.0.0` from the add-on, `3.6.0` from Docker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)