### PR TITLE
Catch InvalidVersion so the #87 workaround can actually run

### DIFF
--- a/toogoodtogo_ha_mqtt_bridge/main.py
+++ b/toogoodtogo_ha_mqtt_bridge/main.py
@@ -518,14 +518,28 @@ def is_latest_version() -> bool:
         logger.exception("Error getting version ID from google playstore. Skipping version check this time.")
         return True
 
-    act_version = version.parse(app_info["version"])
-    token_version = version.parse(tokens["token_version"])
+    try:
+        act_version = version.parse(app_info["version"])
+    except version.InvalidVersion:
+        logger.warning(
+            "Play store reported an unparsable version %r, skipping version check this time.",
+            app_info["version"],
+        )
+        return True
 
     # Fix for users having already a tokens.json contain 'Varies with device'
     # see https://github.com/MaxWinterstein/toogoodtogo-ha-mqtt-bridge/issues/87
-    minor_diff = 999 if str(token_version) == "Varies with device" else act_version.minor - token_version.minor
+    # This has to be caught around the parse: packaging dropped LegacyVersion in
+    # v22, so parse() raises on anything non-PEP440 and the old string compare
+    # below it never got the chance to run.
+    try:
+        token_version: version.Version | None = version.parse(tokens["token_version"])
+    except version.InvalidVersion:
+        token_version = None
 
-    if minor_diff > 2 or act_version.major > token_version.major:
+    minor_diff = 999 if token_version is None else act_version.minor - token_version.minor
+
+    if minor_diff > 2 or (token_version is not None and act_version.major > token_version.major):
         global tgtg_version
         tgtg_version = app_info["version"]
         return False


### PR DESCRIPTION
### The bug

`is_latest_version()` parses both versions, *then* checks whether the token version is the literal `Varies with device`:

```python
act_version = version.parse(app_info["version"])
token_version = version.parse(tokens["token_version"])   # <- raises here

# Fix for users having already a tokens.json contain 'Varies with device'
# see #87
minor_diff = 999 if str(token_version) == "Varies with device" else ...
```

`packaging` removed `LegacyVersion` in v22, so `version.parse("Varies with device")` now raises `InvalidVersion`:

```
>>> version.parse('Varies with device')
packaging.version.InvalidVersion: Invalid version: 'Varies with device'
```

The comparison on the next line is therefore **unreachable**. The workaround for #87 stopped working the moment packaging was bumped, and the exception propagates out of the loop thread.

### The fix

Catch around the parse rather than after it. `token_version` becomes `None` for anything non-PEP440, which feeds the same `minor_diff = 999` the string compare was aiming for — so the outcome is what the original code intended: treat the token as stale and refresh.

Also wrapped the play-store side. That string comes from an external service and is exactly the kind of thing that turns into `Varies with device` without warning; if it does, the check is skipped for this cycle rather than taking the bridge down.

### Behaviour

Identical for every well-formed input:

| act | token | before | after |
|---|---|---|---|
| 25.9.0 | 25.9.0 | `True` | `True` |
| 25.9.0 | 25.8.0 | `True` | `True` |
| 25.9.0 | 25.4.0 | `False` | `False` |
| 26.1.0 | 25.9.0 | `False` | `False` |
| 25.9.0 | `Varies with device` | **`InvalidVersion`** | `False` |

The major-bump row matters: `minor_diff` goes negative there, and the `or` still catches it.

### Checks

`ruff`, `ruff format` and the rest of pre-commit pass; 9/9 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)