### PR TITLE
Point the PyPI links somewhere that exists

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,9 +25,12 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://MaxWinterstein.github.io/toogoodtogo-ha-mqtt-bridge/"
+# Both of these pointed at a GitHub Pages site that has never been enabled
+# for this repository, so the two most prominent links in the PyPI sidebar
+# were 404s. The README is the documentation.
+Homepage = "https://github.com/MaxWinterstein/toogoodtogo-ha-mqtt-bridge"
 Repository = "https://github.com/MaxWinterstein/toogoodtogo-ha-mqtt-bridge"
-Documentation = "https://MaxWinterstein.github.io/toogoodtogo-ha-mqtt-bridge/"
+Documentation = "https://github.com/MaxWinterstein/toogoodtogo-ha-mqtt-bridge#readme"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
Two-line fix.

`Homepage` and `Documentation` in `[project.urls]` both point at:

```
https://MaxWinterstein.github.io/toogoodtogo-ha-mqtt-bridge/   →  404
```

GitHub Pages has never been enabled for this repo. Those are the top two links in the [PyPI sidebar](https://pypi.org/project/toogoodtogo-ha-mqtt-bridge/), so anyone arriving from PyPI hits a dead end twice.

Both now point at the repo; `Documentation` uses `#readme` since the README *is* the documentation.

No version bookkeeping needed — this repo's version comes from git tags via setuptools-scm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)