### PR TITLE
Publish "None" so Home Assistant reads it as no value

### DIFF
--- a/toogoodtogo_ha_mqtt_bridge/main.py
+++ b/toogoodtogo_ha_mqtt_bridge/main.py
@@ -428,7 +428,11 @@ def publish_orders_data(active_orders: dict) -> bool:
     else:
         result_state = publish_state(
             f"{data_base()}/toogoodtogo_next_collection/state",
-            "null",
+            # "None" is the only payload Home Assistant's MQTT sensor reads as
+            # "no value" (PAYLOAD_NONE in homeassistant/components/mqtt/const.py).
+            # "null" is not recognised, and on a device_class: timestamp sensor
+            # it is logged as an invalid state on every poll with no orders.
+            "None",
         )
         result_attrs = publish_state(
             f"{data_base()}/toogoodtogo_next_collection/attr",


### PR DESCRIPTION
One-line fix.

With no active orders, the `next_collection` sensor publishes the literal string `"null"`:

```python
result_state = publish_state(
    f"{data_base()}/toogoodtogo_next_collection/state",
    "null",
)
```

Home Assistant's MQTT sensor recognises exactly **one** payload as "no value":

```python
# homeassistant/components/mqtt/const.py:383
PAYLOAD_NONE = "None"

# homeassistant/components/mqtt/sensor.py:317
if payload == PAYLOAD_NONE:
    self._attr_native_value = None
    return
```

`"null"` doesn't match it and isn't numeric, and this sensor is declared `device_class: timestamp` — so every poll with no orders logs an invalid state instead of clearing the value. That's the normal state for most of the day.

The check happens before any parsing, so `"None"` short-circuits cleanly.

`grep '"null"'` finds no other payloads in the package. 9/9 tests pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)